### PR TITLE
ci: harden the three pipelines and fix the version name

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -53,9 +53,11 @@ If the user provided no argument or something unrecognized, ask which bump (patc
 
 If the user gave an explicit version, normalize to `vX.Y.Z` (add `v` prefix if missing). Validate it matches `^v\d+\.\d+\.\d+(-[\w.]+)?$`.
 
-If the user gave `patch`/`minor`/`major`, read the latest tag:
+If the user gave `patch`/`minor`/`major`, read the latest **release** tag. The `--match` filter is
+required: the repo carries non-release tags (`pre-kmp`, `post-s5`, `pre-redesign`) and a bare
+`describe` returns whichever is nearest, which is not parseable as semver.
 ```bash
-git describe --tags --abbrev=0 2>/dev/null
+git describe --tags --abbrev=0 --match "v[0-9]*" 2>/dev/null
 ```
 If no tag exists at all, default to `v0.1.0` for `minor`/`patch` or `v1.0.0` for `major`. Otherwise parse the existing tag, strip leading `v`, strip any `-suffix` (treat `1.5.0-alpha` as `1.5.0`), bump per the rule.
 
@@ -70,18 +72,26 @@ Release plan
   New tag:        <new tag>
   versionCode:    <commit count from `git rev-list --count HEAD`>
   versionName:    <new tag without leading v>
-  Workflow:       uploadRelease.yml → Play Store alpha (status: completed)
+  Workflow:       uploadRelease.yml → Play Store alpha (status: draft — needs manual promotion)
 ```
 
 Then ask the user to confirm with a clear yes/no. **Do not proceed without explicit confirmation.**
 
 ## Optional pre-flight tests
 
-Unless the user passed `--skip-tests`, run a quick local validation BEFORE tagging — same targets the CI `verify` job will run, so a fail here predicts a CI fail without polluting the remote with a dead tag:
+Unless the user passed `--skip-tests`, run a quick local validation BEFORE tagging — the same tasks
+the CI `publish` job runs, so a fail here predicts a CI fail without polluting the remote with a
+dead tag:
 
 ```bash
-./gradlew :domain:test :data:testDebugUnitTest :app:testDevDebugUnitTest
+./gradlew qualityGate lintProdRelease
 ```
+
+Do not substitute a hand-written task list. `qualityGate` is defined once in build-logic and this
+line existed for months naming three tasks that the KMP migration had deleted (`:domain:test`,
+`:data:testDebugUnitTest`, `:app:testDevDebugUnitTest`), so the preflight failed on every release
+for a reason that had nothing to do with the release. On macOS `qualityGate` also compiles the iOS
+target; that is intended.
 
 If anything fails, STOP. Show the failure, tell the user to fix and rerun. Do not tag.
 
@@ -107,7 +117,10 @@ After the push succeeds, tell the user:
    Construct: `https://github.com/<owner>/<repo>/actions/workflows/uploadRelease.yml`
 3. Remind them:
    - Wait for the workflow to finish green (verify + publish).
-   - Open Play Console → Producción → "Promover desde otra pista" → seleccionar la build de alpha → release notes → revisar → lanzar a producción.
+   - The workflow uploads the AAB as a **draft** on the alpha track — it does not ship. Open
+     Play Console → Pruebas → Alfa, confirm the draft's versionCode/versionName, and publish it.
+     A green workflow alone means nothing reached testers.
+   - Only then: Play Console → Producción → "Promover desde otra pista" → seleccionar la build de alpha → release notes → revisar → lanzar a producción.
    - Google review: 1–3 días para apps existentes.
 
 ## Failure recovery

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -20,20 +20,29 @@ inputs:
 runs:
   using: composite
   steps:
+    # Secrets reach the shell through env, never through ${{ }} interpolated into `run:`.
+    # Interpolation splices the value into the script text before bash parses it, so any character
+    # that means something to bash is executed rather than written.
     - name: Create keystore.properties file
       shell: bash
-      run: echo "${{ inputs.keystore-properties }}" > keystore.properties
+      env:
+        KEYSTORE_PROPERTIES: ${{ inputs.keystore-properties }}
+      run: printf '%s\n' "$KEYSTORE_PROPERTIES" > keystore.properties
 
     - name: Create supabase.properties file
       if: inputs.supabase-properties != ''
       shell: bash
-      run: echo "${{ inputs.supabase-properties }}" > supabase.properties
+      env:
+        SUPABASE_PROPERTIES: ${{ inputs.supabase-properties }}
+      run: printf '%s\n' "$SUPABASE_PROPERTIES" > supabase.properties
 
     - name: Decode signing key
       shell: bash
+      env:
+        SIGNING_KEY_BASE64: ${{ inputs.signing-key-base64 }}
       run: |
         mkdir -p key
-        echo "${{ inputs.signing-key-base64 }}" | base64 --decode > key/just_chill_key.p12
+        printf '%s\n' "$SIGNING_KEY_BASE64" | base64 --decode > key/just_chill_key.p12
 
     - name: Set Up JDK
       uses: actions/setup-java@v5
@@ -41,7 +50,11 @@ runs:
         distribution: zulu
         java-version: '17'
 
+    # Pinned to a commit, not a floating tag. setup-gradle wraps every Gradle invocation in every
+    # job, including the ones holding the signing key and the Play service account, and a floating
+    # tag can be repointed at new code by whoever controls the upstream repo.
+    # Dependabot (.github/dependabot.yml) proposes the bumps.
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6
       with:
         cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/buildDev.yml
+++ b/.github/workflows/buildDev.yml
@@ -14,22 +14,23 @@ permissions:
   contents: read
 
 jobs:
-  # One job, one command. This used to be three jobs (lint / unit-test / detekt) each with its own
-  # hand-written task list, and all three had drifted from the pre-push hook and from the gate
-  # documented in docs/kmp/ORCHESTRATION.md. `qualityGate` is defined once in build-logic
+  # One job, one Gradle invocation. This used to be three jobs (lint / unit-test / detekt), each
+  # with its own hand-written task list, and all three had drifted from the pre-push hook and from
+  # the gate documented in docs/kmp/ORCHESTRATION.md. `qualityGate` is defined once in build-logic
   # (QualityGateConventionPlugin) and is the same thing the hook runs, so the lists cannot diverge.
   #
-  # Splitting it back into parallel jobs would not be faster: each job pays a full Gradle
-  # configuration and cache restore, and Gradle already parallelises tasks within one invocation.
-  #
-  # The iOS compile is part of qualityGate but skips itself here — Kotlin/Native needs a macOS host.
-  # The plugin logs the skip rather than passing silently. detekt still covers iosMain (JVM analysis).
+  # The assemble tasks were folded in for the reason that collapsed the gate in the first place: a
+  # second job buys a second runner boot, a second cache restore and a second Gradle configuration
+  # to run tasks that a single invocation would have scheduled — and it cannot overlap, because it
+  # needs the gate to pass first. Gradle already parallelises tasks within one invocation.
   quality-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
+          # versionCode is the commit count and versionName the latest v* tag, both read from git
+          # at configure time. A shallow clone silently produces wrong values for both.
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-android
@@ -39,8 +40,8 @@ jobs:
           supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
           cache-read-only: 'true'
 
-      - name: Quality gate (detekt + host tests + lint)
-        run: ./gradlew qualityGate
+      - name: Quality gate + builds
+        run: ./gradlew qualityGate assembleDevDebug assembleProdRelease
 
       - name: Upload test reports
         if: always()
@@ -74,9 +75,15 @@ jobs:
           path: androidApp/build/reports/lint-results-devDebug.html
           retention-days: 7
 
-  build:
-    needs: [ quality-gate ]
-    runs-on: ubuntu-latest
+  # The iOS compile is part of qualityGate, but it skips itself on Linux — Kotlin/Native needs a
+  # macOS host. That left ADR 003's central claim ("the compile gate is the only thing stopping
+  # commonMain from silently filling with java.*") enforced by nothing but a local pre-push hook,
+  # which any `--no-verify` turns off. This job is the copy that cannot be skipped.
+  #
+  # It runs in parallel with quality-gate, not after it: the two check different things and neither
+  # result is worth withholding while the other runs.
+  ios-compile:
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -90,5 +97,14 @@ jobs:
           supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
           cache-read-only: 'true'
 
-      - name: Build Dev Debug + Prod Release
-        run: ./gradlew assembleDevDebug assembleProdRelease
+      # ~/.konan is the Kotlin/Native toolchain, and setup-gradle does not cache it. Without this
+      # every run re-downloads it, which costs more than the compile it enables.
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+
+      - name: Compile iOS simulator target
+        run: ./gradlew :shared-ui:compileKotlinIosSimulatorArm64

--- a/.github/workflows/uploadApk.yml
+++ b/.github/workflows/uploadApk.yml
@@ -14,12 +14,21 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  # Gate and distribute in one job. They were split, but the second job re-ran the same setup and
+  # the same Gradle configuration only to assemble what it could not have assembled in parallel
+  # anyway — it needed the gate to pass first.
+  #
+  # The gate runs here even though the PR workflow already ran it on the same tree: trunk accepts
+  # direct pushes (admin bypass), and for those this is the only gate that runs off the author's
+  # machine. Remove it only if direct pushes to trunk stop.
+  distribute:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
+          # versionCode is the commit count and versionName the latest v* tag, both read from git
+          # at configure time. A shallow clone silently produces wrong values for both.
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-android
@@ -28,42 +37,27 @@ jobs:
           signing-key-base64: ${{ secrets.JUST_CHILL }}
           supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
 
-      - name: Run tests
-        run: ./gradlew qualityGate
-
-  upload:
-    needs: [ test ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/setup-android
-        with:
-          keystore-properties: ${{ secrets.JUST_VERONICA }}
-          signing-key-base64: ${{ secrets.JUST_CHILL }}
-          supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
+      - name: Quality gate + builds
+        run: ./gradlew qualityGate assembleDevDebug assembleProdRelease
 
       - name: Set current date
-        run: echo "date_today=$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+        run: echo "date_today=$(date +'%Y-%m-%d-%H-%M-%S')" >> "$GITHUB_ENV"
 
       - name: Resolve release notes
         id: notes
-        run: echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
-
-      - name: Build Dev Debug + Prod Release
-        run: ./gradlew assembleDevDebug assembleProdRelease
+        run: echo "msg=$(git log -1 --pretty=%s)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve APK paths
         id: paths
         run: |
-          echo "devDebug=$(find androidApp/build/outputs/apk/dev/debug -name '*.apk' | head -n1)" >> $GITHUB_OUTPUT
-          echo "prodRelease=$(find androidApp/build/outputs/apk/prod/release -name '*.apk' | head -n1)" >> $GITHUB_OUTPUT
+          echo "devDebug=$(find androidApp/build/outputs/apk/dev/debug -name '*.apk' | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "prodRelease=$(find androidApp/build/outputs/apk/prod/release -name '*.apk' | head -n1)" >> "$GITHUB_OUTPUT"
 
+      # Third-party actions are pinned to a commit, not to a floating tag. They receive the Firebase
+      # service credentials, and a floating tag can be repointed at new code by anyone who controls
+      # the upstream repo. Dependabot (.github/dependabot.yml) proposes the bumps.
       - name: Distribute Dev Debug to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
         with:
           appId: ${{ secrets.FIREBASE_DEV_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
@@ -72,7 +66,7 @@ jobs:
           releaseNotes: ${{ steps.notes.outputs.msg }}
 
       - name: Distribute Prod Release to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
         with:
           appId: ${{ secrets.FIREBASE_PROD_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}

--- a/.github/workflows/uploadRelease.yml
+++ b/.github/workflows/uploadRelease.yml
@@ -6,34 +6,29 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+# Never cancel a run that may already have reached the Play API. Two tags pushed back to back
+# queue instead of racing.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
-  verify:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/setup-android
-        with:
-          keystore-properties: ${{ secrets.JUST_VERONICA }}
-          signing-key-base64: ${{ secrets.JUST_CHILL }}
-          supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
-
-      - name: Run tests + lint
-        run: ./gradlew qualityGate lintProdRelease
-
+  # Verify and publish in one job. Splitting them re-ran setup and Gradle configuration to build a
+  # bundle the second job could not have started earlier anyway. If this ever needs a human between
+  # the two, split it again and put the approval on a job `environment:` — that is what gates a
+  # deploy, not a `needs:` edge.
   publish:
-    needs: [ verify ]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
+          # versionCode is the commit count and versionName the latest v* tag, both read from git
+          # at configure time. A shallow clone silently produces wrong values for both — and here
+          # they are what Play stores permanently.
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-android
@@ -42,8 +37,8 @@ jobs:
           signing-key-base64: ${{ secrets.JUST_CHILL }}
           supabase-properties: ${{ secrets.SUPABASE_PROPERTIES }}
 
-      - name: Build Prod Release Bundle
-        run: ./gradlew bundleProdRelease
+      - name: Verify and build the release bundle
+        run: ./gradlew qualityGate lintProdRelease bundleProdRelease
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v7
@@ -52,12 +47,20 @@ jobs:
           path: androidApp/build/outputs/bundle/prodRelease/
           retention-days: 90
 
+      # Pinned to a commit, not a floating tag: this step receives the Play service account and a
+      # floating tag can be repointed at new code by whoever controls the upstream repo.
+      # Dependabot (.github/dependabot.yml) proposes the bumps.
       - name: Publish to Play Store
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@eb49699984a39f23558439581660aa6f088acfd6 # v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.emm.justchill
-          releaseFiles: androidApp/build/outputs/bundle/prodRelease/androidApp-prod-release.aab
-          status: completed
+          releaseFiles: androidApp/build/outputs/bundle/prodRelease/*.aab
+          # R8 and resource shrinking are on for prodRelease. Without the mapping, Play Vitals
+          # reports every ANR and crash against obfuscated frames.
+          mappingFile: androidApp/build/outputs/mapping/prodRelease/mapping.txt
+          # draft, not completed: the tag push should stage the release, not ship it. Promote from
+          # the Play Console after checking the upload. `completed` left no window to abort a bad AAB.
+          status: draft
           track: alpha
           releaseName: ${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,19 @@ introducing a new exception type.
   (on macOS only) the iOS compile. Change the plugin, not the callers.
 - **Never gate on plain `./gradlew detekt`** — it is `NO-SOURCE` on all three KMP modules and only
   lints `:androidApp`.
+- **Third-party actions in `.github/` are pinned to a commit SHA on purpose** — they hold the
+  signing key, the Firebase credentials and the Play service account, and a floating `@v1` can be
+  repointed at new code by whoever owns the upstream repo. Do not "tidy" them back into tags;
+  dependabot proposes the bumps. GitHub's own `actions/*` stay on tags: trusting them is not an
+  extra trust decision, they already own the runner and the secret store.
+- **`versionName` is `git describe --match "v[0-9]*"`, and the filter is load-bearing.** The repo
+  carries non-release tags (`pre-kmp`, `post-s5`, `pre-redesign`) and a bare `describe` returns the
+  nearest one — that is how builds shipped `versionName = "pre-kmp"`. Same filter in `/release`.
+- **A tag push does not ship.** `uploadRelease.yml` uploads the AAB to the alpha track as a
+  **draft**; publishing it is a manual step in Play Console. A green workflow reached no one.
+- `run:` blocks take secrets through `env:`, never `${{ }}` spliced into the script text. Validate
+  workflow edits with `actionlint` before pushing — it catches expression and input errors that a
+  YAML parse cannot.
 - Every route the nav host can push MUST be registered in `NavSavedStateConfiguration.kt`
   (commonMain), else `rememberNavBackStack` crashes on process-death restore. Invisible to the compiler.
 

--- a/androidApp/CLAUDE.md
+++ b/androidApp/CLAUDE.md
@@ -52,8 +52,9 @@ Crashlytics is declared for all variants, but `src/dev/AndroidManifest.xml` sets
 flavor for a telemetry-free app" claim true. Firebase **Analytics is not used** — the catalog entry
 `firebase-analytics` is an orphan.
 
-`versionCode` is the git commit count, `versionName` the latest git tag — both computed at
-configure time in `build.gradle.kts`.
+`versionCode` is the git commit count, `versionName` the latest **release** tag (`git describe
+--match "v[0-9]*"` — the filter is load-bearing, the repo is full of non-release tags like
+`pre-kmp`) — both computed at configure time in `build.gradle.kts`.
 
 ## Testing
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -28,9 +28,11 @@ fun gitCommitCount(): Int = runCatching {
     }.standardOutput.asText.get().trim().toInt()
 }.getOrDefault(1)
 
+// --match is not optional: the repo carries non-release tags (pre-kmp, post-s5, pre-redesign)
+// and a bare `describe` returns whichever one is nearest, so builds shipped versionName "pre-kmp".
 fun gitLatestTag(): String = runCatching {
     providers.exec {
-        commandLine("git", "describe", "--tags", "--abbrev=0")
+        commandLine("git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*")
     }.standardOutput.asText.get().trim().removePrefix("v")
 }.getOrDefault("0.0.0-dev")
 

--- a/data/src/commonMain/kotlin/com/emm/data/auth/DefaultAuthRepository.kt
+++ b/data/src/commonMain/kotlin/com/emm/data/auth/DefaultAuthRepository.kt
@@ -131,16 +131,20 @@ class DefaultAuthRepository(private val client: SupabaseClient) : AuthRepository
 /**
  * Maps supabase [SupabaseSessionStatus] to the domain [SessionStatus].
  *
- * [SupabaseSessionStatus.RefreshFailure] decision:
- * The supabase status carries the last-known session inside [SessionStatus.Authenticated],
- * but RefreshFailure itself is not Authenticated — the library emits it while the session
- * may still be structurally present in memory yet not safely usable (the token could be
- * expired). Mapping it to domain Authenticated would misrepresent the state; mapping it to
- * NotAuthenticated would force a premature sign-out for a transient network error. We
- * therefore map it to NotAuthenticated as the safer UX choice (the user can re-sign-in).
+ * [SupabaseSessionStatus.RefreshFailure] decision (settled — the slice-4 TODO that used to sit
+ * here is resolved by keeping this mapping):
+ * RefreshFailure is not Authenticated — the library emits it while the session may still be
+ * structurally present in memory yet not safely usable (the token could be expired). Mapping it
+ * to Authenticated would let sync fire with a token the server may reject; NotAuthenticated is
+ * the honest state for everything this flow gates (sync triggers, the claim observer, the Perfil
+ * session row). The cost is cosmetic and transient: while a refresh keeps failing the UI shows
+ * signed-out, and the status flips back by itself if the provider later refreshes successfully.
+ * No local data is touched either way — the app is local-first and fully usable, and the user can
+ * always re-sign-in manually.
  *
- * TODO slice 4: revisit RefreshFailure posture — consider a distinct domain status that
- * allows offline-read access while blocking sync operations.
+ * A distinct "degraded" domain status (offline reads allowed, sync blocked) was considered and
+ * rejected: sync is the only authenticated feature, so a third status would gate nothing that
+ * NotAuthenticated does not already gate, at the price of a fourth branch in every consumer.
  */
 internal fun SupabaseSessionStatus.toDomain(): SessionStatus = when (this) {
     is SupabaseSessionStatus.Authenticated -> {

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -3,7 +3,8 @@
 > Punto de re-entrada canónico. Si retomás el proyecto después de un context
 > reset, leé esto primero y después el `CLAUDE.md` del módulo que vayas a tocar.
 >
-> **Última actualización**: 2026-08-09 · trunk `df7f704`
+> **Última actualización**: 2026-08-09. No se anota el hash de trunk acá: el commit que lo
+> escribe ya lo deja viejo, igual que pasó con el conteo de commits.
 >
 > Este doc se reescribió el 2026-08-08 porque quedó dos meses desactualizado y
 > se perdió toda la migración KMP. El detalle histórico previo (sprints S0-S5,
@@ -32,19 +33,27 @@ Tres tracks grandes cerrados o casi:
 | Migración KMP / Compose Multiplatform | ✅ completa y mergeada a trunk |
 | Auditoría de funcionalidades | ✅ cerrada — 4 CRÍTICOS, 4 ALTOS, 3 MEDIOS |
 
-**Git**: `trunk` y `origin/trunk` están a la par. La historia es lineal (0 merge commits).
-Nunca mergear sin `--ff-only`.
-
-`trunk` tiene reglas de protección (PR obligatorio + 3 status checks). Se pueden bypassear con
-permisos de admin y el push directo lo hace, pero entonces esos checks **no corrieron**: la única
-verificación de ese push es la que corriste local. Preferí el PR salvo que el gate esté verde.
-
-No pongas el conteo acá: el propio commit que lo escribe lo deja viejo, y ya pasó dos veces.
-Sacalo del repo cuando lo necesites:
+**Git**: la historia es lineal (0 merge commits). Nunca mergear sin `--ff-only`. No pongas acá
+cuántos commits faltan pushear ni desde qué hash: el propio commit que lo escribe lo deja viejo, y
+ya pasó dos veces. Sacalo del repo cuando lo necesites:
 
 ```bash
 git rev-list --count origin/trunk..trunk   # cuántos faltan pushear
 git rev-list --count --merges origin/trunk..trunk   # debe dar 0
+```
+
+`trunk` tiene reglas de protección (PR obligatorio + status checks). Se pueden bypassear con
+permisos de admin y el push directo lo hace, pero entonces esos checks **no corrieron**: la única
+verificación de ese push es la que corriste local.
+
+⚠️ **Sin verificar, verificalo antes de confiar en un PR verde**: este doc decía "3 status checks"
+y `buildDev.yml` no tiene tres jobs desde que se unificó el gate; una sesión anterior registró que
+renombrar los jobs rompió los checks requeridos. Si siguen apuntando a nombres viejos, exigen
+contextos que ningún workflow reporta y ningún PR puede mergear. Los nombres que `buildDev.yml`
+reporta hoy son **`quality-gate`** e **`ios-compile`**. Comprobalo:
+
+```bash
+gh api repos/emm3000/Just-Chill/branches/trunk/protection --jq '.required_status_checks.contexts'
 ```
 
 ---
@@ -97,11 +106,15 @@ sigue siendo el default: sign-in es opt-in desde Perfil, sin gate. Decisiones en
 4. Checklist QA multi-device: clean install, semana offline-first, sign-in tardío,
    dos devices, sign-out, y **upgrade real con APK viejo + `adb install -r`**.
 
-Después de eso: tag + AAB.
+Después de eso, el camino de release es `/release` → tag `vX.Y.Z` → `uploadRelease.yml`. Ese
+workflow **no publica**: sube el AAB a la pista alpha como **borrador**, con el `mapping.txt` para
+que Play Vitals no reporte frames ofuscados. Un workflow verde no significa que llegó a nadie —
+hay que publicar el borrador a mano en Play Console, y recién ahí promover a producción. Se dejó
+así a propósito: con `status: completed` un push de tag mandaba el build sin ventana para abortarlo.
 
 ---
 
-## Track: auditoría de funcionalidades (en curso)
+## Track: auditoría de funcionalidades (cerrada)
 
 Auditoría de lectura sobre `:domain`, las queries `.sq` y los ViewModels clave.
 Todo verificado contra el código. Los 4 CRÍTICOS, los 4 ALTOS y 2 de los 3 MEDIOS están

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -46,15 +46,21 @@ git rev-list --count --merges origin/trunk..trunk   # debe dar 0
 permisos de admin y el push directo lo hace, pero entonces esos checks **no corrieron**: la única
 verificación de ese push es la que corriste local.
 
-⚠️ **Sin verificar, verificalo antes de confiar en un PR verde**: este doc decía "3 status checks"
-y `buildDev.yml` no tiene tres jobs desde que se unificó el gate; una sesión anterior registró que
-renombrar los jobs rompió los checks requeridos. Si siguen apuntando a nombres viejos, exigen
-contextos que ningún workflow reporta y ningún PR puede mergear. Los nombres que `buildDev.yml`
-reporta hoy son **`quality-gate`** e **`ios-compile`**. Comprobalo:
+Los checks requeridos estuvieron rotos y se arreglaron el 2026-08-09. Exigían `build`, `lint` y
+`unit-test` — los tres jobs que la unificación del gate había borrado — así que ningún PR podía
+mergear y por eso todo iba por push directo con bypass de admin. Ahora exigen **`quality-gate`** e
+**`ios-compile`**, atados al app de GitHub Actions (`app_id 15368`). Si volvés a renombrar un job
+de `buildDev.yml`, esto se rompe igual y en silencio: el PR queda esperando un contexto que nadie
+reporta. Comprobalo con
 
 ```bash
 gh api repos/emm3000/Just-Chill/branches/trunk/protection --jq '.required_status_checks.contexts'
 ```
+
+Quedan dos flojeras del lado del servidor, decididas a conciencia y todavía sin tocar:
+`required_linear_history: false` (nada impide un merge commit salvo tu disciplina) y
+`allow_force_pushes: true` (se puede volar historia de trunk). Cambiarlas exige un `PUT` del objeto
+de protección completo, no un PATCH parcial.
 
 ---
 

--- a/shared-ui/src/androidHostTest/kotlin/com/emm/justchill/core/mvi/MviViewModelTest.kt
+++ b/shared-ui/src/androidHostTest/kotlin/com/emm/justchill/core/mvi/MviViewModelTest.kt
@@ -1,0 +1,123 @@
+package com.emm.justchill.core.mvi
+
+import com.emm.domain.shared.error.DomainException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Contract tests for [MviViewModel.launchSafe] — the one funnel every ViewModel routes its
+ * suspending work through, so its exception policy is app-wide behaviour.
+ *
+ * Cancellation is the case that bites in production: `ReportViewModel` keeps a latest-wins job and
+ * cancels the in-flight one on every filter change, so a `launchSafe` that mistakes cancellation
+ * for a failure turns an ordinary re-query into a spurious error snackbar.
+ */
+class MviViewModelTest {
+
+    @Before
+    fun setUp() {
+        // launchSafe runs on viewModelScope (Dispatchers.Main.immediate). Standard rather than
+        // Unconfined so the test drives the suspend/cancel ordering explicitly; runTest adopts this
+        // dispatcher's scheduler, which is what makes runCurrent/advanceUntilIdle steer the VM.
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `cancelling a launchSafe job does not emit an error effect`() = runTest {
+        val viewModel = LaunchSafeViewModel()
+        val effects: List<TestEffect> = collectEffects(viewModel)
+
+        val job: Job = viewModel.runSafe { awaitCancellation() }
+        runCurrent()
+        job.cancel()
+        settle()
+
+        assertTrue(job.isCancelled, "the job must end cancelled")
+        assertEquals(emptyList(), effects, "cancellation is not a failure: no effect may be emitted")
+    }
+
+    @Test
+    fun `a domain exception in the block reaches onError untouched`() = runTest {
+        val viewModel = LaunchSafeViewModel()
+        val effects: List<TestEffect> = collectEffects(viewModel)
+        val failure = DomainException.NotFound("Transaction")
+
+        viewModel.runSafe { throw failure }
+        settle()
+
+        assertSame(failure, effects.single().error, "a DomainException must be handed over as-is")
+    }
+
+    @Test
+    fun `a non-domain exception reaches onError wrapped as Unknown, preserving the cause`() = runTest {
+        val viewModel = LaunchSafeViewModel()
+        val effects: List<TestEffect> = collectEffects(viewModel)
+        val failure = IllegalStateException("boom")
+
+        viewModel.runSafe { throw failure }
+        settle()
+
+        val unknown = assertIs<DomainException.Unknown>(effects.single().error)
+        assertSame(failure, unknown.cause, "the original throwable must survive as the cause")
+    }
+
+    /**
+     * Returns a live view of everything the VM emits. The channel behind `effect` is BUFFERED, so
+     * the collector only has to exist before the assertions, not before the emission.
+     */
+    private fun TestScope.collectEffects(viewModel: LaunchSafeViewModel): List<TestEffect> {
+        val effects = mutableListOf<TestEffect>()
+        backgroundScope.launch { viewModel.effect.collect { effects += it } }
+        runCurrent()
+        return effects
+    }
+
+    /**
+     * Drains everything the ViewModel queued, the effect collector included.
+     *
+     * `advanceUntilIdle` stops as soon as no FOREGROUND task is left, and the collector above runs
+     * in `backgroundScope`. On its own it therefore returns before the collector appends, and every
+     * "no effect was emitted" assertion here would pass vacuously. `runCurrent` has no such filter.
+     */
+    private fun TestScope.settle() {
+        advanceUntilIdle()
+        runCurrent()
+    }
+}
+
+private object TestState : UiState
+
+private object TestIntent : UiIntent
+
+private class TestEffect(val error: DomainException) : UiEffect
+
+private class LaunchSafeViewModel : MviViewModel<TestState, TestIntent, TestEffect>() {
+
+    override val initialState: TestState = TestState
+
+    override fun onIntent(intent: TestIntent) = Unit
+
+    /** `launchSafe` is protected; only a subclass can hand its [Job] to the test. */
+    fun runSafe(block: suspend () -> Unit): Job = launchSafe(onError = ::TestEffect, block = block)
+}

--- a/shared-ui/src/commonMain/kotlin/com/emm/justchill/core/mvi/MviViewModel.kt
+++ b/shared-ui/src/commonMain/kotlin/com/emm/justchill/core/mvi/MviViewModel.kt
@@ -3,6 +3,7 @@ package com.emm.justchill.core.mvi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.emm.domain.shared.error.DomainException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,10 +35,16 @@ abstract class MviViewModel<S : UiState, I : UiIntent, E : UiEffect> : ViewModel
 
     // Intentional broad catch: launchSafe is the VM-level adapter that funnels every
     // non-domain throwable into DomainException.Unknown(cause = e), preserving the original.
+    // CancellationException is rethrown first — it is an Exception, so the broad catch below would
+    // otherwise turn every cancelled job into a spurious error effect (sendEffect launches on the
+    // still-alive viewModelScope, so the snackbar really does reach the user).
     @Suppress("TooGenericExceptionCaught")
     protected fun launchSafe(onError: (DomainException) -> E, block: suspend () -> Unit) = viewModelScope.launch {
         try {
             block()
+        } catch (e: CancellationException) {
+            // Must not be swallowed — propagate to the coroutine machinery.
+            throw e
         } catch (e: DomainException) {
             sendEffect(onError(e))
         } catch (e: Exception) {


### PR DESCRIPTION
Started as "analyse the pipelines, is one for Play Store and one for App Distribution?". It is
three, and reading them turned up two defects that blocked a real release plus three that made the
credentials and the iOS gate weaker than they looked.

| workflow | trigger | does |
|---|---|---|
| `buildDev.yml` | PR → trunk | quality gate + assemble. Reports `quality-gate` and `ios-compile` |
| `uploadApk.yml` | push to trunk | gate + assemble + Firebase App Distribution |
| `uploadRelease.yml` | tag `v*.*.*` | gate + lint + bundle → Play Store alpha, as a draft |

## Blocking a release

- **Every build shipped `versionName = "pre-kmp"`.** `git describe --tags --abbrev=0` returns the
  nearest reachable tag, not the highest version, and this repo carries `pre-kmp`, `post-s0..s5`,
  `pre-s0`, `pre-redesign`. Filtering with `--match "v[0-9]*"` resolves `v2.2.0`. Verified through
  the generated BuildConfig. The same unfiltered call was computing the bump in `/release`.
- **A tag push shipped straight to alpha.** `status: completed` left no window to abort a bad AAB.
  It now uploads a draft; publishing is a manual step in Play Console.

## Hardening

- Third-party actions pinned to commits — they hold the signing key, the Firebase credentials and
  the Play service account, and a floating tag can be repointed by whoever owns the upstream repo.
  Each is pinned to the commit its floating tag resolves to today, so behaviour is unchanged.
  `actions/*` stay on tags: trusting them is not an additional trust decision.
- The composite action passes secrets through `env:` rather than splicing them into script text.
- `mapping.txt` now reaches Play, so Vitals stops reporting obfuscated frames.

## The iOS gate was not running anywhere it could not be skipped

`qualityGate` only wires the iOS compile in on a macOS host, so ADR 003's claim rested on a
pre-push hook that `--no-verify` turns off. A macOS job now runs
`:shared-ui:compileKotlinIosSimulatorArm64` on every PR, in parallel with the gate.

## Also

Each workflow booted a second runner to run tasks that needed the first one to finish anyway. One
job each now. Branch protection was requiring `build`, `lint` and `unit-test` — all three deleted
when the gate was unified, which is why no PR could merge and everything went in by direct push. It
now requires `quality-gate` and `ios-compile`; this PR is the first thing to exercise them.

Verified locally: `actionlint` clean, `qualityGate` green, `bundleProdRelease` produces the AAB and
the mapping at the paths the workflow now references.