### PR TITLE
fix(domain): stop edits from shifting transaction timestamps

### DIFF
--- a/domain/src/androidHostTest/kotlin/com/emm/domain/shared/DateAndTimeCombinerTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/shared/DateAndTimeCombinerTest.kt
@@ -1,8 +1,11 @@
 package com.emm.domain.shared
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -14,25 +17,51 @@ class DateAndTimeCombinerTest {
 
     private val combiner = DateAndTimeCombiner()
 
+    /** UTC-5. Local evenings fall on the next UTC day. */
+    private val lima = TimeZone.of("America/Lima")
+
+    /** UTC+5. Local midnight falls on the previous UTC day. */
+    private val karachi = TimeZone.of("Asia/Karachi")
+
     @Test
-    fun `combineWithUtc preserves the date when interpreted as UTC`() {
+    fun `combineWithCurrentTime preserves the date the picker selected`() {
         val targetDate = LocalDate(2026, 5, 15)
-        val dateInMillis = targetDate.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        val dateInMillis = targetDate.atStartOfDayIn(lima).toEpochMilliseconds()
 
-        val result = combiner.combineWithUtc(dateInMillis)
+        val result = DateAndTimeCombiner(lima).combineWithCurrentTime(dateInMillis)
 
-        val zone = TimeZone.currentSystemDefault()
-        val resultDate = Instant.fromEpochMilliseconds(result).toLocalDateTime(zone).date
-        assertEquals(targetDate, resultDate)
+        assertEquals(targetDate, result.dateIn(lima))
     }
 
     @Test
-    fun `combineWithUtc uses current wall-clock time`() {
+    fun `combineWithCurrentTime is idempotent for a stored evening timestamp`() {
+        val storedDate = LocalDate(2026, 5, 15)
+        val storedEvening = LocalDateTime(storedDate, LocalTime(21, 48))
+            .toInstant(lima)
+            .toEpochMilliseconds()
+
+        val result = DateAndTimeCombiner(lima).combineWithCurrentTime(storedEvening)
+
+        assertEquals(storedDate, result.dateIn(lima))
+    }
+
+    @Test
+    fun `combineWithCurrentTime preserves the date in zones ahead of UTC`() {
+        val targetDate = LocalDate(2026, 5, 15)
+        val dateInMillis = targetDate.atStartOfDayIn(karachi).toEpochMilliseconds()
+
+        val result = DateAndTimeCombiner(karachi).combineWithCurrentTime(dateInMillis)
+
+        assertEquals(targetDate, result.dateIn(karachi))
+    }
+
+    @Test
+    fun `combineWithCurrentTime uses current wall-clock time`() {
         val zone = TimeZone.currentSystemDefault()
-        val dateInMillis = LocalDate(2026, 5, 15).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        val dateInMillis = LocalDate(2026, 5, 15).atStartOfDayIn(zone).toEpochMilliseconds()
 
         val beforeMillis = Clock.System.now().toEpochMilliseconds()
-        val result = combiner.combineWithUtc(dateInMillis)
+        val result = combiner.combineWithCurrentTime(dateInMillis)
         val afterMillis = Clock.System.now().toEpochMilliseconds()
 
         val resultTime = Instant.fromEpochMilliseconds(result).toLocalDateTime(zone).time
@@ -48,4 +77,46 @@ class DateAndTimeCombinerTest {
             "Expected result time $resultTime to be within ±${toleranceSeconds}s of [$beforeTime, $afterTime]",
         )
     }
+
+    @Test
+    fun `combineKeepingTimeOf moves the day and carries the original time along`() {
+        val original = LocalDateTime(LocalDate(2026, 5, 15), LocalTime(13, 5))
+            .toInstant(lima)
+            .toEpochMilliseconds()
+        val newDay = LocalDate(2026, 5, 20).atStartOfDayIn(lima).toEpochMilliseconds()
+
+        val result = DateAndTimeCombiner(lima).combineKeepingTimeOf(newDay, original)
+
+        assertEquals(LocalDateTime(LocalDate(2026, 5, 20), LocalTime(13, 5)), result.dateTimeIn(lima))
+    }
+
+    @Test
+    fun `combineKeepingTimeOf returns the very same instant when the day did not change`() {
+        val stored = LocalDateTime(LocalDate(2026, 5, 15), LocalTime(21, 48))
+            .toInstant(lima)
+            .toEpochMilliseconds()
+
+        val result = DateAndTimeCombiner(lima).combineKeepingTimeOf(stored, stored)
+
+        assertEquals(stored, result)
+    }
+
+    @Test
+    fun `combineKeepingTimeOf ignores the time carried by the day argument`() {
+        val original = LocalDateTime(LocalDate(2026, 5, 15), LocalTime(8, 30))
+            .toInstant(lima)
+            .toEpochMilliseconds()
+        val newDayAtNoon = LocalDateTime(LocalDate(2026, 5, 20), LocalTime(12, 0))
+            .toInstant(lima)
+            .toEpochMilliseconds()
+
+        val result = DateAndTimeCombiner(lima).combineKeepingTimeOf(newDayAtNoon, original)
+
+        assertEquals(LocalDateTime(LocalDate(2026, 5, 20), LocalTime(8, 30)), result.dateTimeIn(lima))
+    }
+
+    private fun Long.dateIn(zone: TimeZone): LocalDate = dateTimeIn(zone).date
+
+    private fun Long.dateTimeIn(zone: TimeZone): LocalDateTime =
+        Instant.fromEpochMilliseconds(this).toLocalDateTime(zone)
 }

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/transaction/CreateTransactionUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/transaction/CreateTransactionUseCaseTest.kt
@@ -36,7 +36,7 @@ class CreateTransactionUseCaseTest {
     @Test
     fun `create should call repository with combined date and provided id`() = runTest {
         every { idProvider.id } returns "fixed-id"
-        every { dateAndTimeCombiner.combineWithUtc(1_000L) } returns 9_999L
+        every { dateAndTimeCombiner.combineWithCurrentTime(1_000L) } returns 9_999L
         coEvery { repository.create(any()) } just Runs
 
         useCase(anyInsert)
@@ -51,7 +51,7 @@ class CreateTransactionUseCaseTest {
     @Test
     fun `create should overwrite caller-provided id with idProvider`() = runTest {
         every { idProvider.id } returns "generated"
-        every { dateAndTimeCombiner.combineWithUtc(any()) } returns 0L
+        every { dateAndTimeCombiner.combineWithCurrentTime(any()) } returns 0L
         coEvery { repository.create(any()) } just Runs
 
         useCase(anyInsert.copy(id = TransactionId("caller-tried-this")))
@@ -64,7 +64,7 @@ class CreateTransactionUseCaseTest {
     @Test
     fun `create should propagate DomainException from repository`() = runTest {
         every { idProvider.id } returns "id"
-        every { dateAndTimeCombiner.combineWithUtc(any()) } returns 0L
+        every { dateAndTimeCombiner.combineWithCurrentTime(any()) } returns 0L
         coEvery { repository.create(any()) } throws DomainException.DatabaseError(RuntimeException("boom"))
 
         val ex = assertFailsWith<DomainException.DatabaseError> { useCase(anyInsert) }

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/transaction/UpdateTransactionUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/transaction/UpdateTransactionUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertFailsWith
@@ -21,7 +22,10 @@ class UpdateTransactionUseCaseTest {
     private val dateAndTimeCombiner = mockk<DateAndTimeCombiner>()
     private val useCase = UpdateTransactionUseCase(repository, dateAndTimeCombiner)
 
-    private val oldTransaction = Transaction.Empty.copy(transactionId = TransactionId("tx-1"))
+    private val oldTransaction = Transaction.Empty.copy(
+        transactionId = TransactionId("tx-1"),
+        date = 1_500L,
+    )
     private val anyUpdate = TransactionUpdate(
         type = TransactionType.Spend,
         amount = Money(5000L),
@@ -33,7 +37,7 @@ class UpdateTransactionUseCaseTest {
 
     @Test
     fun `update should call repository with combined date and original transactionId`() = runTest {
-        every { dateAndTimeCombiner.combineWithUtc(2_000L) } returns 7_777L
+        every { dateAndTimeCombiner.combineKeepingTimeOf(2_000L, 1_500L) } returns 7_777L
         coEvery { repository.update(any(), any()) } just Runs
 
         useCase(oldTransaction, anyUpdate)
@@ -47,8 +51,23 @@ class UpdateTransactionUseCaseTest {
     }
 
     @Test
+    fun `update should take the time of day from the stored transaction, not from the update`() = runTest {
+        every { dateAndTimeCombiner.combineKeepingTimeOf(any(), any()) } returns 0L
+        coEvery { repository.update(any(), any()) } just Runs
+
+        useCase(oldTransaction, anyUpdate)
+
+        verify(exactly = 1) {
+            dateAndTimeCombiner.combineKeepingTimeOf(
+                dateInMillis = anyUpdate.date,
+                timeSourceInMillis = oldTransaction.date,
+            )
+        }
+    }
+
+    @Test
     fun `update should keep other update fields intact`() = runTest {
-        every { dateAndTimeCombiner.combineWithUtc(any()) } returns 0L
+        every { dateAndTimeCombiner.combineKeepingTimeOf(any(), any()) } returns 0L
         coEvery { repository.update(any(), any()) } just Runs
 
         useCase(oldTransaction, anyUpdate)
@@ -69,7 +88,7 @@ class UpdateTransactionUseCaseTest {
 
     @Test
     fun `update should propagate DomainException from repository`() = runTest {
-        every { dateAndTimeCombiner.combineWithUtc(any()) } returns 0L
+        every { dateAndTimeCombiner.combineKeepingTimeOf(any(), any()) } returns 0L
         coEvery { repository.update(any(), any()) } throws DomainException.NotFound("transaction")
 
         assertFailsWith<DomainException.NotFound> { useCase(oldTransaction, anyUpdate) }

--- a/domain/src/commonMain/kotlin/com/emm/domain/shared/DateAndTimeCombiner.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/shared/DateAndTimeCombiner.kt
@@ -1,24 +1,37 @@
 package com.emm.domain.shared
 
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-class DateAndTimeCombiner {
+/**
+ * Builds a timestamp out of a calendar day taken from one value and a time of day taken from
+ * another. Both ends are resolved in [zone]; reading the day in UTC instead would shift it by one
+ * whenever the local time of day sits on the other side of UTC midnight.
+ */
+class DateAndTimeCombiner(private val zone: TimeZone = TimeZone.currentSystemDefault()) {
 
-    fun combineWithUtc(dateInMillis: Long): Long {
-        val selectedDateTime: kotlinx.datetime.LocalDateTime = Instant
-            .fromEpochMilliseconds(dateInMillis)
-            .toLocalDateTime(TimeZone.UTC)
+    /**
+     * Day from [dateInMillis], time of day from the clock. For transactions being created, where
+     * the picker only carries a day and "now" is the best guess at when it happened.
+     */
+    fun combineWithCurrentTime(dateInMillis: Long): Long =
+        combine(dateInMillis, Clock.System.now().toLocalDateTime(zone).time)
 
-        val systemZone: TimeZone = TimeZone.currentSystemDefault()
-        val currentTime = Clock.System.now().toLocalDateTime(systemZone).time
+    /**
+     * Day from [dateInMillis], time of day from [timeSourceInMillis]. For transactions being
+     * edited: moving one to another day must not restamp the hour it was recorded at. Passing the
+     * same value twice returns it unchanged, so re-saving an untouched date is a no-op.
+     */
+    fun combineKeepingTimeOf(dateInMillis: Long, timeSourceInMillis: Long): Long =
+        combine(dateInMillis, timeSourceInMillis.localDateTime().time)
 
-        val combinedDateTime = LocalDateTime(selectedDateTime.date, currentTime)
+    private fun combine(dateInMillis: Long, time: LocalTime): Long =
+        LocalDateTime(dateInMillis.localDateTime().date, time).toInstant(zone).toEpochMilliseconds()
 
-        return combinedDateTime.toInstant(systemZone).toEpochMilliseconds()
-    }
+    private fun Long.localDateTime(): LocalDateTime = Instant.fromEpochMilliseconds(this).toLocalDateTime(zone)
 }

--- a/domain/src/commonMain/kotlin/com/emm/domain/transaction/CreateTransactionUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/transaction/CreateTransactionUseCase.kt
@@ -19,7 +19,7 @@ class CreateTransactionUseCase(
                 ValidationCode.AmountMustBePositive,
             )
         }
-        val dateAndTimeCombined: Long = dateAndTimeCombiner.combineWithUtc(transactionInsert.date)
+        val dateAndTimeCombined: Long = dateAndTimeCombiner.combineWithCurrentTime(transactionInsert.date)
         val transaction: TransactionInsert = transactionInsert.copy(
             id = TransactionId(uniqueIdProvider.id),
             date = dateAndTimeCombined,

--- a/domain/src/commonMain/kotlin/com/emm/domain/transaction/UpdateTransactionUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/transaction/UpdateTransactionUseCase.kt
@@ -16,7 +16,10 @@ class UpdateTransactionUseCase(
                 ValidationCode.AmountMustBePositive,
             )
         }
-        val dateAndTimeCombined: Long = dateAndTimeCombiner.combineWithUtc(transactionUpdate.date)
+        val dateAndTimeCombined: Long = dateAndTimeCombiner.combineKeepingTimeOf(
+            dateInMillis = transactionUpdate.date,
+            timeSourceInMillis = oldTransaction.date,
+        )
         val updatedTransaction: TransactionUpdate = transactionUpdate.copy(date = dateAndTimeCombined)
         repository.update(
             transactionId = oldTransaction.transactionId,

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModel.kt
@@ -212,7 +212,7 @@ class AddTransactionViewModel(
 
     private fun updateCurrentDate(millis: Long?) = millis?.let {
         dateInLong = it
-        updateState { copy(date = DateUtils.friendlyDateUTC(it)).touched() }
+        updateState { copy(date = DateUtils.friendlyDate(it)).touched() }
     }
 }
 

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/DateUtils.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/DateUtils.kt
@@ -19,13 +19,6 @@ object DateUtils {
         return SpanishDateFormat.longDate(today)
     }
 
-    fun millisToReadableFormatUTC(millis: Long): String {
-        val date: LocalDate = Instant.fromEpochMilliseconds(millis)
-            .toLocalDateTime(TimeZone.UTC)
-            .date
-        return SpanishDateFormat.longDate(date)
-    }
-
     fun currentDateInMillis(): Long {
         val zone = TimeZone.currentSystemDefault()
         return today(zone).atStartOfDayIn(zone).toEpochMilliseconds()
@@ -41,8 +34,6 @@ object DateUtils {
             else -> SpanishDateFormat.dayShortMonth(date).titlecaseFirstChar()
         }
     }
-
-    fun friendlyDateUTC(millis: Long): String = friendlyDate(millis, TimeZone.UTC)
 
     fun readableTime(millis: Long): String {
         val time = Instant.fromEpochMilliseconds(millis)

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModel.kt
@@ -172,7 +172,7 @@ class EditTransactionViewModel(
 
     private fun updateCurrentDate(millis: Long?) = millis?.let {
         dateInLong = it
-        updateState { copy(date = DateUtils.friendlyDateUTC(it)).recompute() }
+        updateState { copy(date = DateUtils.friendlyDate(it)).recompute() }
     }
 
     private data class Snapshot(


### PR DESCRIPTION
Reported as "I create a transaction, then edit it, and the date moves a day forward". It does, it is
worse than one day, and the same root cause was breaking transaction creation outside the Americas.

## The defect

`DateAndTimeCombiner` read the incoming calendar day in `TimeZone.UTC` but built the resulting
instant in `TimeZone.currentSystemDefault()`. Two different zones on the two ends of one operation.

Its two callers do not hand it the same kind of value:

| caller | receives | outcome |
|---|---|---|
| `CreateTransactionUseCase` | local midnight — `DatePickerSheet` emits `atStartOfDayIn(zone)` | correct **by accident** at negative offsets |
| `UpdateTransactionUseCase` | `oldTransaction.date`, a full stored timestamp with a time of day | broken |

`EditTransactionViewModel` seeds `dateInLong` with the stored timestamp, so a transaction saved at
21:30 in Lima (`2026-08-11T02:30Z`) read back as **August 11**. One day forward, on every save, and
the shift compounds: three edits move a transaction three days.

Reproduced on an emulator in `America/Lima` at 21:48, straight out of the SQLDelight file:

| | `date` | local |
|---|---|---|
| created | `1786416485751` | 2026-08-10 **21:48** |
| after 1 edit | `1786502940429` | 2026-08-11 **21:49** |
| after 2 edits | `1786589367655` | 2026-08-12 **21:49** |

Delta 86,454,678 ms — exactly 24h plus the seconds spent tapping.

## The fix

Read the day in the same zone the instant is built in. That alone makes the operation idempotent,
which is the property the update path always needed and never had.

The API is now split so each caller states which time of day it wants, rather than both sharing one
function that guesses:

- `combineWithCurrentTime(date)` — the clock. A new transaction has no recorded hour, so now is the
  best available guess.
- `combineKeepingTimeOf(date, timeSource)` — the stored hour. Editing a transaction must not
  restamp when it happened; correcting the amount of a 1:15 p.m. lunch at 10 p.m. used to move it to
  10 p.m.

`combineKeepingTimeOf(x, x)` returns `x` unchanged, so re-saving an untouched date is now an exact
no-op rather than merely landing on the same day.

`EditTransactionViewModel` needed no change: `dateInLong` starts at the stored timestamp and becomes
local midnight when the user picks another day, and only the **day** is read off it either way.

## A second bug the first one was hiding

The UTC read also broke **creation** at positive offsets, in the opposite direction: local midnight
in `Asia/Karachi` falls on the previous UTC day, so new transactions would land a day *early*. Never
visible from Peru, and no test running on a UTC CI box could have caught it either — which is why
the zone is now an injectable constructor parameter defaulted to the system one. The Koin binding
(`factory { DateAndTimeCombiner() }`) is untouched.

`DateUtils.friendlyDateUTC` carried the same mixed contract, reading UTC off a local-midnight value,
and is gone along with its two call sites. `millisToReadableFormatUTC` was already dead and went
with it — leaving a UTC-reading formatter next to this fix invites the bug straight back.

## Verification

TDD: both regression tests failed before the logic was touched.

```
combineWithCurrentTime is idempotent for a stored evening timestamp   FAILED  ← the report
combineWithCurrentTime preserves the date in zones ahead of UTC       FAILED  ← the latent one
```

13 tests green (7 on the combiner, 6 on the update use case) and `./gradlew qualityGate` passes,
iOS compile included.

Re-validated on the emulator with the wall clock reading 22:04:

| action | result |
|---|---|
| edit the amount of a **13:15** transaction | `2026-08-10 13:15:00` — untouched, to the second |
| move its date to August 6 | `2026-08-06 13:15:00` — day moves, hour travels with it |

## Not covered

Timestamps already corrupted on a device are not repaired; there are no users on either platform, so
no migration was written. If that changes before release, this needs one.
