### PR TITLE
fix(transaction): date the new transaction when it is saved, not when the screen opened

### DIFF
--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModelTest.kt
@@ -50,13 +50,23 @@ class AddTransactionViewModelTest {
 
     private val lima = TimeZone.of("America/Lima")
     private val today = LocalDate(2026, Month.AUGUST, 10)
+    private val tomorrow = LocalDate(2026, Month.AUGUST, 11)
 
-    /** Fixed at 2026-08-10 14:30 Lima, so "today" never depends on when the suite runs. */
-    private val fixedClock = object : Clock {
-        override fun now(): Instant = Instant.fromEpochMilliseconds(
-            LocalDateTime(today, LocalTime(14, 30)).toInstant(lima).toEpochMilliseconds(),
-        )
+    /**
+     * Movable so a test can hold a ViewModel across midnight — the case that made the add screen
+     * write the wrong day. Starts at 2026-08-10 14:30 Lima, so "today" never depends on when the
+     * suite runs.
+     */
+    private class MovableClock(var instant: Instant) : Clock {
+        override fun now(): Instant = instant
     }
+
+    private fun instantAt(date: LocalDate, hour: Int, minute: Int): Instant =
+        Instant.fromEpochMilliseconds(
+            LocalDateTime(date, LocalTime(hour, minute)).toInstant(lima).toEpochMilliseconds(),
+        )
+
+    private val fixedClock = MovableClock(instantAt(today, hour = 14, minute = 30))
 
     private val account1 = Account(AccountId("yape"), "Yape")
     private val account2 = Account(AccountId("bcp"), "BCP")
@@ -110,13 +120,88 @@ class AddTransactionViewModelTest {
     // ── the selected date lives in the state ──────────────────────────────────
 
     @Test
-    fun `date defaults to today from the injected clock`() = runTest(testDispatcher) {
+    fun `date starts unset and reads as Hoy`() = runTest(testDispatcher) {
         val vm = buildViewModel()
         advanceUntilIdle()
 
-        assertEquals(today, vm.state.value.date)
+        // Unset, not "today resolved at construction": nobody has picked a day yet, and which day
+        // "Hoy" is has no answer until the transaction is actually saved.
+        assertNull(vm.state.value.date)
         assertEquals(today, vm.state.value.today)
         assertEquals("Hoy", vm.state.value.dateLabel)
+    }
+
+    // ── the day is resolved when saving, not when the screen opened ───────────
+
+    @Test
+    fun `an untouched date saves as the day it is saved on, not the day the screen opened`() =
+        runTest(testDispatcher) {
+            val vm = buildViewModel()
+            advanceUntilIdle()
+
+            // The screen was opened just before midnight and sat there. Resolving "Hoy" at
+            // construction booked the movement on the previous day, silently.
+            fixedClock.instant = instantAt(tomorrow, hour = 0, minute = 5)
+
+            vm.onIntent(AddTransactionIntent.OnAmountChange("8540"))
+            advanceUntilIdle()
+            vm.onIntent(AddTransactionIntent.OnSave)
+            advanceUntilIdle()
+
+            val insert = slot<TransactionInsert>()
+            coVerify { createTransaction.invoke(capture(insert)) }
+            assertEquals(tomorrow.atStartOfDayIn(lima).toEpochMilliseconds(), insert.captured.date)
+        }
+
+    @Test
+    fun `a picked date is not re-resolved when the clock rolls over`() = runTest(testDispatcher) {
+        val vm = buildViewModel()
+        advanceUntilIdle()
+
+        val picked = LocalDate(2026, Month.JUNE, 13)
+        vm.onIntent(AddTransactionIntent.OnDateSelected(picked))
+        vm.onIntent(AddTransactionIntent.OnAmountChange("8540"))
+        advanceUntilIdle()
+
+        fixedClock.instant = instantAt(tomorrow, hour = 0, minute = 5)
+
+        vm.onIntent(AddTransactionIntent.OnSave)
+        advanceUntilIdle()
+
+        val insert = slot<TransactionInsert>()
+        coVerify { createTransaction.invoke(capture(insert)) }
+        assertEquals(picked.atStartOfDayIn(lima).toEpochMilliseconds(), insert.captured.date)
+    }
+
+    @Test
+    fun `today catches up on the next interaction after midnight`() = runTest(testDispatcher) {
+        val vm = buildViewModel()
+        advanceUntilIdle()
+        assertEquals(today, vm.state.value.today)
+
+        fixedClock.instant = instantAt(tomorrow, hour = 0, minute = 5)
+        vm.onIntent(AddTransactionIntent.OnAmountChange("1"))
+        advanceUntilIdle()
+
+        // Every intent re-reads the clock, so a screen left open overnight stops claiming that
+        // yesterday is "Hoy" as soon as the user touches anything.
+        assertEquals(tomorrow, vm.state.value.today)
+    }
+
+    @Test
+    fun `a date picked yesterday reads as Ayer once the day rolls over`() = runTest(testDispatcher) {
+        val vm = buildViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(AddTransactionIntent.OnDateSelected(today))
+        advanceUntilIdle()
+        assertEquals("Hoy", vm.state.value.dateLabel)
+
+        fixedClock.instant = instantAt(tomorrow, hour = 0, minute = 5)
+        vm.onIntent(AddTransactionIntent.OnAmountChange("1"))
+        advanceUntilIdle()
+
+        assertEquals("Ayer", vm.state.value.dateLabel)
     }
 
     @Test
@@ -150,7 +235,7 @@ class AddTransactionViewModelTest {
     }
 
     @Test
-    fun `OnReset returns the date to today`() = runTest(testDispatcher) {
+    fun `OnReset puts the date back to unset`() = runTest(testDispatcher) {
         val vm = buildViewModel()
         advanceUntilIdle()
 
@@ -160,7 +245,9 @@ class AddTransactionViewModelTest {
         vm.onIntent(AddTransactionIntent.OnReset)
         advanceUntilIdle()
 
-        assertEquals(today, vm.state.value.date)
+        // Unset rather than today: the next transaction is dated when it is saved, and the add
+        // screen is reset after every save, so it can easily outlive the day it was opened on.
+        assertNull(vm.state.value.date)
         assertEquals("Hoy", vm.state.value.dateLabel)
     }
 

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModelTest.kt
@@ -57,12 +57,20 @@ class EditTransactionViewModelTest {
     private val lima = TimeZone.of("America/Lima")
     private val today = LocalDate(2026, Month.AUGUST, 10)
 
-    /** Fixed at 2026-08-10 14:30 Lima, so "today" never depends on when the suite runs. */
-    private val fixedClock = object : Clock {
-        override fun now(): Instant = Instant.fromEpochMilliseconds(
-            LocalDateTime(today, LocalTime(14, 30)).toInstant(lima).toEpochMilliseconds(),
-        )
+    /**
+     * Movable so a test can hold the screen across midnight. Starts at 2026-08-10 14:30 Lima, so
+     * "today" never depends on when the suite runs.
+     */
+    private class MovableClock(var instant: Instant) : Clock {
+        override fun now(): Instant = instant
     }
+
+    private fun instantAt(date: LocalDate, hour: Int, minute: Int): Instant =
+        Instant.fromEpochMilliseconds(
+            LocalDateTime(date, LocalTime(hour, minute)).toInstant(lima).toEpochMilliseconds(),
+        )
+
+    private val fixedClock = MovableClock(instantAt(today, hour = 14, minute = 30))
 
     private val account = Account(AccountId("bcp"), "BCP")
 
@@ -144,6 +152,25 @@ class EditTransactionViewModelTest {
         advanceUntilIdle()
 
         assertEquals(today, vm.state.value.today)
+    }
+
+    @Test
+    fun `today catches up on the next interaction after midnight`() = runTest(testDispatcher) {
+        coEvery { findTransaction.invoke(TransactionId("tx-1")) } returns
+            storedTransaction.copy(date = LocalDateTime(today, LocalTime(9, 15)).toInstant(lima).toEpochMilliseconds())
+
+        val vm = buildViewModel()
+        advanceUntilIdle()
+        assertEquals("Hoy", vm.state.value.dateLabel)
+
+        fixedClock.instant = instantAt(LocalDate(2026, Month.AUGUST, 11), hour = 0, minute = 5)
+        vm.onIntent(EditTransactionIntent.OnAmountChange("9000"))
+        advanceUntilIdle()
+
+        // The transaction did not move; the day under it did. A screen left open overnight must
+        // stop calling yesterday "Hoy" as soon as the user touches anything.
+        assertEquals(today, vm.state.value.date)
+        assertEquals("Ayer", vm.state.value.dateLabel)
     }
 
     @Test

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionUiState.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionUiState.kt
@@ -9,15 +9,21 @@ import kotlinx.datetime.LocalDate
 
 data class AddTransactionUiState(
     /**
-     * The day the transaction is being recorded for. This is the date — the label below is derived
-     * from it, and the save path and the date picker both read it.
+     * Today, as of the last time the ViewModel's clock was read. Reference day for [dateLabel]'s
+     * Hoy/Ayer branch, and what an unset [date] resolves to.
      *
-     * It has no default: there is no day to record against without asking a clock, and the state
-     * is not the place that asks. The ViewModel supplies it from its injected [kotlin.time.Clock].
+     * It has no default: there is no answer without asking a clock, and a state class is not what
+     * asks. The ViewModel supplies it from its injected [kotlin.time.Clock].
      */
-    val date: LocalDate,
-    /** Reference day for [dateLabel]'s Hoy/Ayer branch, from the same clock as [date]. */
     val today: LocalDate,
+    /**
+     * The day the transaction is being recorded for, or `null` while the user has not picked one.
+     *
+     * `null` is not "no date" — it is *the day this gets saved on*, and it stays unresolved until
+     * the save happens. Resolving it up front is what made a screen opened at 23:59 and saved at
+     * 00:01 book the movement on the previous day, silently and with the label still reading "Hoy".
+     */
+    val date: LocalDate? = null,
     val amount: String = "",
     val description: String = String.Empty,
     val transactionType: TransactionType = TransactionType.Income,
@@ -30,8 +36,16 @@ data class AddTransactionUiState(
     val frequentCategoryIds: List<String> = emptyList(),
     val frequentCombos: List<FrequentComboUi> = emptyList(),
 ) : UiState {
-    /** "Hoy" / "Ayer" / "13 jun" — derived, so it cannot drift away from [date]. */
-    val dateLabel: String get() = relativeDayLabel(date, today)
+    /**
+     * "Hoy" / "Ayer" / "13 jun" — derived, so it cannot drift away from [date].
+     *
+     * An unset [date] is "Hoy" without consulting anything, which is the one label that cannot go
+     * stale: it stays true across midnight because it names the save, not a day.
+     */
+    val dateLabel: String get() = date?.let { relativeDayLabel(it, today) } ?: "Hoy"
+
+    /** The day the picker should open on: the picked one, or today when nothing is picked yet. */
+    val pickerDate: LocalDate get() = date ?: today
 
     val missingField: MissingField? get() = when {
         centsToSoles(amount) <= 0.0 -> MissingField.Amount

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionViewModel.kt
@@ -39,7 +39,7 @@ class AddTransactionViewModel(
     private val zone: TimeZone = TimeZone.currentSystemDefault(),
 ) : MviViewModel<AddTransactionUiState, AddTransactionIntent, AddTransactionEffect>() {
 
-    override val initialState = AddTransactionUiState(date = today(), today = today())
+    override val initialState = AddTransactionUiState(today = today())
 
     private val allCategories: MutableMap<CategoryType, List<SelectableCategory>> = mutableMapOf()
 
@@ -77,6 +77,10 @@ class AddTransactionViewModel(
     }
 
     override fun onIntent(intent: AddTransactionIntent) {
+        // Every interaction re-reads the clock, so a screen left open overnight stops claiming that
+        // yesterday is "Hoy". StateFlow drops the emission when the day has not changed, which is
+        // every intent but the handful that cross midnight.
+        updateState { copy(today = today()) }
         when (intent) {
             is AddTransactionIntent.OnAmountChange -> updateState { copy(amount = intent.value).touched() }
 
@@ -132,12 +136,10 @@ class AddTransactionViewModel(
     private fun reset() {
         updateState {
             val defaultType = TransactionType.Income
-            // The clock is re-read here, not reused from construction: the add screen is reset
-            // after every save and can outlive the day it was opened on.
             copy(
                 amount = "",
                 description = String.Empty,
-                date = today(),
+                date = null,
                 today = today(),
                 transactionType = defaultType,
                 categories = allCategories[defaultType.categoryType].orEmpty(),
@@ -210,10 +212,13 @@ class AddTransactionViewModel(
     // The one place the picked day becomes an instant. CreateTransactionUseCase then swaps this
     // midnight for the current time of day — the day is what the user chose, the hour is when it
     // was recorded.
+    //
+    // An unset day resolves against the clock HERE, not against the state's `today`: this is the
+    // moment the transaction gets a date, and it is the only reading that cannot already be stale.
     private fun createTransactionInsert(): TransactionInsert = TransactionInsert(
         type = currentState.transactionType,
         description = currentState.description,
-        date = startOfDayMillis(currentState.date, zone),
+        date = startOfDayMillis(currentState.date ?: today(), zone),
         amount = centsToMoney(currentState.amount),
         categoryId = currentState.categorySelected?.categoryId,
         accountId = currentState.accountSelected?.accountId

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/transaction/EditTransactionViewModel.kt
@@ -54,6 +54,10 @@ class EditTransactionViewModel(
     }
 
     override fun onIntent(intent: EditTransactionIntent) {
+        // Every interaction re-reads the clock, so a screen left open overnight stops labelling
+        // yesterday's transaction "Hoy". StateFlow drops the emission when the day has not changed.
+        // Only the label moves: `date` is the transaction's own day and is never re-resolved.
+        updateState { copy(today = today()) }
         when (intent) {
             is EditTransactionIntent.OnAmountChange -> updateState { copy(amount = intent.value).recompute() }
 

--- a/presentation/src/commonTest/kotlin/com/emm/justchill/hh/transaction/TransactionDateStateTest.kt
+++ b/presentation/src/commonTest/kotlin/com/emm/justchill/hh/transaction/TransactionDateStateTest.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
  * The date these two states carry used to be a formatted `String`, with the real value hidden in a
@@ -22,14 +23,14 @@ class TransactionDateStateTest {
 
     @Test
     fun add_state_carries_the_selected_day_itself() {
-        val state = AddTransactionUiState(date = LocalDate(2026, Month.MARCH, 4), today = today)
+        val state = AddTransactionUiState(today = today, date = LocalDate(2026, Month.MARCH, 4))
 
         assertEquals(LocalDate(2026, Month.MARCH, 4), state.date)
     }
 
     @Test
     fun add_state_label_is_derived_from_the_selected_day() {
-        val state = AddTransactionUiState(date = today, today = today)
+        val state = AddTransactionUiState(today = today, date = today)
 
         assertEquals("Hoy", state.dateLabel)
         assertEquals("4 mar", state.copy(date = LocalDate(2026, Month.MARCH, 4)).dateLabel)
@@ -39,10 +40,35 @@ class TransactionDateStateTest {
     @Test
     fun add_state_label_follows_a_copy_of_the_value() {
         // A stored label would survive this copy unchanged. That is the drift being designed out.
-        val state = AddTransactionUiState(date = today, today = today)
+        val state = AddTransactionUiState(today = today, date = today)
 
         assertEquals("Hoy", state.dateLabel)
         assertEquals("13 jun", state.copy(date = LocalDate(2026, Month.JUNE, 13)).dateLabel)
+    }
+
+    // ── an unset day means "whenever this gets saved" ─────────────────────────
+
+    @Test
+    fun add_state_day_is_unset_until_one_is_picked() {
+        assertNull(AddTransactionUiState(today = today).date)
+    }
+
+    @Test
+    fun add_state_reads_an_unset_day_as_Hoy_whatever_today_is() {
+        // No clock is consulted for this label, so it cannot go stale: an unset day *is* Hoy, on
+        // whichever day the transaction ends up being saved.
+        assertEquals("Hoy", AddTransactionUiState(today = today).dateLabel)
+        assertEquals("Hoy", AddTransactionUiState(today = LocalDate(2027, Month.JANUARY, 1)).dateLabel)
+    }
+
+    @Test
+    fun add_state_picked_day_is_labelled_against_today() {
+        // A day the user picked is a fact and stays put; only its label moves as today does.
+        val picked = AddTransactionUiState(today = today, date = today)
+
+        assertEquals("Hoy", picked.dateLabel)
+        assertEquals("Ayer", picked.copy(today = LocalDate(2026, Month.AUGUST, 11)).dateLabel)
+        assertEquals(today, picked.copy(today = LocalDate(2026, Month.AUGUST, 11)).date)
     }
 
     // ── EditTransactionUiState ────────────────────────────────────────────────
@@ -67,7 +93,7 @@ class TransactionDateStateTest {
         val day = LocalDate(2026, Month.SEPTEMBER, 1)
 
         assertEquals(
-            AddTransactionUiState(date = day, today = today).dateLabel,
+            AddTransactionUiState(today = today, date = day).dateLabel,
             EditTransactionUiState(date = day, today = today).dateLabel,
         )
     }

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/transaction/AddTransactionScreen.kt
@@ -285,7 +285,7 @@ private fun AddTransactionScreenContent(
 
     if (showDateSheet) {
         DatePickerSheet(
-            currentDate = state.date,
+            currentDate = state.pickerDate,
             onConfirm = { date -> onIntent(AddTransactionIntent.OnDateSelected(date)) },
             onDismiss = { showDateSheet = false },
         )
@@ -321,7 +321,6 @@ private fun AddTransactionPreview() {
         }
         AddTransactionScreenContent(
             state = AddTransactionUiState(
-                date = LocalDate(2026, Month.AUGUST, 10),
                 today = LocalDate(2026, Month.AUGUST, 10),
                 categories = categories,
                 amount = "8540",


### PR DESCRIPTION
> Stacked on #71 — review that one first. This PR targets its branch, and the diff below is only
> the second commit.

#71 left one finding from the date audit open, and this is it: the add screen resolved "today" while
it was being built and kept the answer. A screen opened at 23:59 and saved at 00:01 booked the
movement on **the previous day**, silently, with the date chip still reading "Hoy" — the label was
resolved at the same moment and went stale with it.

The screen is not short-lived either. It is `reset()` after every save rather than recreated, so a
single session can outlive several midnights and every transaction saved in it carries the day the
screen was first opened.

## The defect

The state was collapsing two different things into one field. "I have not picked a day" and "I
picked today" are not the same claim, and only the second one is a date. Storing the first as the
second is what forces the resolution to happen too early.

| | before | now |
|---|---|---|
| nothing picked | `date = today()` at construction | `date = null` |
| user picked a day | `date = LocalDate` | `date = LocalDate` |

## The fix

`AddTransactionUiState.date` is nullable, and `null` is not "no date" — it is *the day this gets
saved on*, still unresolved:

- **It resolves inside `createTransactionInsert`**, against the clock, not against the state's
  `today`. That is the moment the transaction actually gets a date and the only reading that cannot
  already be stale.
- **Its label needs no clock at all.** An unset day *is* "Hoy", on whichever day the save lands, so
  that string is now the only label in the app that cannot go stale.
- **`OnReset` returns the field to unset** rather than to today, which is what makes the
  reset-after-save loop safe across a midnight.

A day the user picked stays put. It is a fact, and nothing re-resolves it — only its label moves as
today does, which is why `a picked date is not re-resolved when the clock rolls over` is in the
suite next to the main regression.

### The reference day

The other half of the staleness is the `today` both screens compare against for the Hoy/Ayer branch,
seeded once at construction. Both ViewModels now re-read the clock at the top of `onIntent`, so any
interaction corrects it — and on the add screen every saved transaction needs an amount typed, which
is a dozen intents before the save.

This is free when the day has not changed: the `copy` is equal and `StateFlow` drops the emission.

The edit screen keeps its own day and only its label moves. A transaction's date is a stored fact;
none of this may re-resolve it, and `today catches up on the next interaction after midnight` asserts
exactly that — the label goes to "Ayer" while `date` stays put.

## Verification

The regression test was inverted to prove it has teeth. Seeding `date` at construction again — the
old behaviour — fails it by exactly one day:

```
an untouched date saves as the day it is saved on, not the day the screen opened
  AssertionError: Expected <1786424400000>, actual <1786338000000>
```

86,400,000 ms apart. Both ViewModel suites hold a movable clock so the screen can be held across
midnight without touching the system one.

`./gradlew qualityGate` passes, iOS compile included.

Emulator (`America/Lima`): the add screen opens with the chip on "Hoy" and the picker on Agosto 11;
picking 13 July moves the chip to "13 jul", and reopening the sheet returns to `Julio 2026` /
`Confirmar · 13 julio` rather than to today — the unset day resolving to today for the picker while
a picked one is kept. No crashes.

**The midnight rollover itself was not exercised on device.** Moving the emulator clock needs `adb
root`, which is not available here; the day boundary is covered by the inverted unit test above
instead.

## Not covered

- **The timezone is still ambient on the read path.** The write path takes an injected `TimeZone`;
  `TransactionUi.toUi` still resolves days through the system default, matching the rest of the repo.
- **A label can still sit stale while nobody touches the screen.** `today` corrects on interaction,
  not on a timer. A midnight ticker would close that, but it is an infinite delay-loop flow and
  `advanceUntilIdle()` — which three existing ViewModel suites rely on — advances virtual time into
  it forever. That needs a different testing approach than the one this repo currently uses, so it
  is deliberately not in here.
- Neither the picker nor the schema guards a future date. Unchanged, and still open from the audit.
