### PR TITLE
fix(data): harden the sync cursor, count the frequency window in days, and track the audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/*
 !docs/PLAY_ADVERTISING_ID.md
 !docs/PRIVACY_POLICY.md
 !docs/AUTH_SYNC_UI_BLUEPRINT.md
+!docs/DATE_AUDIT.md
 # Supabase
 supabase.properties
 supabase/.temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,9 @@ CMP Gradle plugin is applied nowhere. `:presentation` still uses JetBrains' mult
 - `PROGRESS.md` — canonical "where are we now". Read it first.
 - `adr/` — filenames state the decision; 004 amends 002, 005 supersedes 003's frozen-UI scope.
 - `kmp/ORCHESTRATION.md` — slice workflow + ledger. `sync/PLAN.md`, `swiftui/PLAN.md` — slice status.
+- `DATE_AUDIT.md` — the 13 date-handling findings and what closed each. Read before touching dates;
+  #5 (the schema stores an instant where the app means a calendar day) is still open and is the one
+  that gets expensive after launch.
 - `PLAY_ADVERTISING_ID.md` — the app does not use the advertising ID, with the commands that prove
   it on any AAB. Read before answering Play's declaration; the console currently says "Yes", wrongly.
 - `DESIGN_SYSTEM.md` — tokens and components (its paths still point at the pre-KMP `app/` module).

--- a/data/src/commonMain/kotlin/com/emm/data/sync/BaseTableSync.kt
+++ b/data/src/commonMain/kotlin/com/emm/data/sync/BaseTableSync.kt
@@ -9,7 +9,7 @@ import com.emm.domain.sync.SyncLogger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /** Composite keyset position used to paginate through a remote table. */
 data class PullPageKey(val serverUpdatedAt: String, val pk: String)
@@ -238,7 +238,7 @@ abstract class BaseTableSync<DTO : SyncRowDto>(
         val page = fetchRemotePage(userId, overlapCursor, after, pageSize)
         if (page.isEmpty()) return PageResult(null, false, null, stop = true)
 
-        var maxInstant: Instant? = null
+        val mark = CursorHighWaterMark()
         var skipped = false
 
         safeDbCall {
@@ -273,9 +273,12 @@ abstract class BaseTableSync<DTO : SyncRowDto>(
                             markPendingForResync(pkOf(remote))
                     }
 
-                    remote.serverUpdatedAt?.let { sat ->
-                        val inst = parseServerInstant(sat)
-                        if (maxInstant == null || inst > maxInstant!!) maxInstant = inst
+                    if (!mark.offer(remote.serverUpdatedAt)) {
+                        // Same class of problem as the null serverUpdatedAt guard below, and just
+                        // as invisible: the row applied, but it cannot advance the cursor. Holding
+                        // the cursor re-pulls this window next cycle.
+                        logger.warn("pull hit unparseable serverUpdatedAt table=$tableName pk=${pkOf(remote)}")
+                        skipped = true
                     }
                 }
             }
@@ -300,7 +303,31 @@ abstract class BaseTableSync<DTO : SyncRowDto>(
         // arrives is therefore deferred to subsequent cycles by design (same posture as the
         // pre-pagination cursor-hold semantics).
         val nextKey = if (isLastPage) null else PullPageKey(serverUpdatedAt = lastSat!!, pk = pkOf(page.last()))
-        return PageResult(maxInstant, skipped || nullSatGuard, nextKey, stop = isLastPage)
+        return PageResult(mark.value, skipped || nullSatGuard, nextKey, stop = isLastPage)
+    }
+
+    /**
+     * Highest `server_updated_at` seen while applying a page — the value the pull cursor advances
+     * to. Its own type so the parse, the comparison and the unreadable-value case stay out of the
+     * row loop, which reads one branch per policy decision and is complexity-capped.
+     */
+    private class CursorHighWaterMark {
+
+        var value: Instant? = null
+            private set
+
+        /**
+         * Offers one row's raw `server_updated_at`. Returns false only when a value was present and
+         * could not be parsed — an absent one is normal for a row this page did not advance past.
+         */
+        fun offer(raw: String?): Boolean {
+            val parsed = raw?.let(::parseServerInstant)
+            if (parsed != null) {
+                val current = value
+                if (current == null || parsed > current) value = parsed
+            }
+            return raw == null || parsed != null
+        }
     }
 
     companion object {

--- a/data/src/commonMain/kotlin/com/emm/data/sync/DefaultSyncRepository.kt
+++ b/data/src/commonMain/kotlin/com/emm/data/sync/DefaultSyncRepository.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 private const val SESSION_RESOLVE_TIMEOUT_MS = 10_000L
 

--- a/data/src/commonMain/kotlin/com/emm/data/sync/SyncCursorUtils.kt
+++ b/data/src/commonMain/kotlin/com/emm/data/sync/SyncCursorUtils.kt
@@ -1,11 +1,25 @@
 package com.emm.data.sync
 
-import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
-internal fun parseServerInstant(value: String): Instant = Instant.parse(value)
+/**
+ * Parses a `server_updated_at` value, or null when it is not a timestamp this client understands.
+ *
+ * Nullable because the string is remote input like any other column. [BaseTableSync] already guards
+ * the case where the server sends no value at all; a value it cannot read is the same kind of
+ * problem and must not be the one that throws — the parse happens inside the per-page database
+ * transaction, so an exception there takes down the whole pull rather than one row.
+ */
+internal fun parseServerInstant(value: String): Instant? = runCatching { Instant.parse(value) }.getOrNull()
 
+/**
+ * The stored cursor, rewound by [OVERLAP_SECONDS] so a pull re-reads the rows around where the last
+ * one stopped. Null when there is no cursor, or when the stored one cannot be parsed — both mean
+ * "start from the beginning", which is the self-healing answer: a full re-pull is idempotent, and a
+ * cursor the client cannot read would otherwise wedge sync permanently.
+ */
 internal fun overlapCursor(cursor: String?): String? =
-    cursor?.let { (parseServerInstant(it) - OVERLAP_SECONDS.seconds).toString() }
+    cursor?.let(::parseServerInstant)?.let { (it - OVERLAP_SECONDS.seconds).toString() }
 
 private const val OVERLAP_SECONDS = 10L

--- a/data/src/commonTest/kotlin/com/emm/data/sync/SyncCursorUtilsTest.kt
+++ b/data/src/commonTest/kotlin/com/emm/data/sync/SyncCursorUtilsTest.kt
@@ -1,11 +1,11 @@
 package com.emm.data.sync
 
-import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 /**
  * Pins [parseServerInstant] and [overlapCursor] behaviour.
@@ -68,8 +68,29 @@ class SyncCursorUtilsTest {
     fun `parseServerInstant round-trip offset input produces Z form toString`() {
         // After parse the Instant.toString() must be in canonical Z form, never "+00:00".
         val input = "2026-06-10T01:23:45.123456+00:00"
-        val result = parseServerInstant(input).toString()
+        val result = assertNotNull(parseServerInstant(input)).toString()
         assertTrue(result.endsWith("Z"), "Expected Z-terminated string, got: $result")
+    }
+
+    // -------------------------------------------------------------------------
+    // parseServerInstant — input the client cannot read
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parseServerInstant returns null rather than throwing on a malformed value`() {
+        // The parse runs inside the per-page database transaction in BaseTableSync. Throwing there
+        // takes down the whole pull; returning null lets the row be skipped and the cursor held.
+        assertNull(parseServerInstant("not a timestamp"))
+        assertNull(parseServerInstant(""))
+        assertNull(parseServerInstant("2026-06-10"))
+        assertNull(parseServerInstant("2026-13-45T99:99:99Z"))
+    }
+
+    @Test
+    fun `overlapCursor returns null for a cursor the client cannot parse`() {
+        // A stored cursor that cannot be read means "start from the beginning" rather than "fail
+        // forever": the full re-pull is idempotent, and LWW makes the re-applied rows a no-op.
+        assertNull(overlapCursor("not a timestamp"))
     }
 
     // -------------------------------------------------------------------------

--- a/docs/DATE_AUDIT.md
+++ b/docs/DATE_AUDIT.md
@@ -1,0 +1,84 @@
+# Date handling — audit tracker
+
+End-to-end audit of dates, from the picker down to the column, run on 2026-08-10. Thirteen findings.
+This file is the tracker; the reasoning for each fix lives in its PR.
+
+Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
+
+## P0 — visible to the user
+
+- [x] **1. The date picker never received the selected date.** Both screens passed
+  `DateUtils.currentDateInMillis()`, so the calendar always opened on today — editing a March
+  transaction opened on the current month. Root cause: the UiState carried a formatted label while
+  the value lived in a `private var` on the ViewModel. → **#71**
+- [x] **2. The day was resolved when the screen opened, not when it saved.** A screen opened at
+  23:59 and saved at 00:01 booked the movement on the previous day, silently, with the chip still
+  reading "Hoy". → **#72**
+- [x] **3. Two Spanish month tables that disagreed.** `MonthLabels` spelled September "Setiembre"
+  where `SpanishDateFormat` — golden-tested against `es-PE` — spelled it "septiembre". Both reached
+  the screen. → **#71**
+- [x] **4. `EditTransactionUiState` defaulted to a different date format** ("10 de agosto de 2026"
+  where every other path rendered "Hoy"). Died with `DateUtils`. → **#71**
+
+## P1 — modelling
+
+- [ ] **5. The model confuses an instant with a calendar day.** `transactions.date` is epoch millis —
+  an instant — but the domain treats it as a day. This does not break on one device. It breaks with
+  **sync**: a device in Lima records "10 Aug 23:30", a device in Madrid pulls it and shows 11 Aug,
+  and at a month boundary it moves between months and changes the Reporte. LWW does not help — it is
+  not a conflict, it is the same instant rendered differently. `docs/sync/PLAN.md` does not cover it.
+
+  Suggested direction: store the calendar day the transaction *means* (`'YYYY-MM-DD'`) alongside the
+  instant, and window every month query on that. `RecurringDueRules.periodKey` already proves the
+  pattern works in this codebase. **Needs a product decision and a migration — the only finding here
+  that touches the schema, and the one that gets expensive once there are users.**
+
+- [ ] **6. A global clock hidden in entity constructors.** `currentTimeInMillis()`
+  (`domain/shared/DateExtensions.kt`) is called from **19 sites**, including the default arguments of
+  `TransactionInsert`, `AccountUpsert` and `Transaction.Empty`. An entity that reads the wall clock
+  on construction is doing hidden I/O: it is not injectable, not testable, and `createdAt` and
+  `updatedAt` are two separate reads that can differ by a millisecond.
+
+  Mechanical but wide. The `Clock` seam the transaction ViewModels now use is the shape to copy.
+
+- [~] **7. The timezone is ambient where the clock is injected.** `YearMonth.startInclusiveMillis`,
+  `GetHomeDataUseCase` and the `TransactionUi` read path all resolve days through
+  `TimeZone.currentSystemDefault()`. The clock can be faked in tests; the zone cannot, so no test can
+  cover a month boundary in another zone. *Partially closed:* the transaction write path and the
+  frequency-window use cases take an injected `TimeZone` (#71, #73).
+
+- [x] **8. A "last 90 days" window measured in fixed milliseconds.** `now - days * 24h` is a
+  duration, not a number of days; it drifts by an hour across a DST change and starts mid-morning
+  otherwise. Duplicated in two use cases. → **#73**
+
+## P2 — consistency and hardening
+
+- [x] **9. Deprecated `kotlinx.datetime.Instant`** in four `data/sync` files while the rest of the
+  repo used `kotlin.time.Instant`. → **#73**
+- [x] **10. `Instant.parse` on server input with no guard**, inside the per-page database
+  transaction. The class guarded a *missing* `server_updated_at` but not an unreadable one, so a
+  malformed value took down the whole pull. → **#73**
+- [ ] **11. Nothing guards a future date.** The picker navigates forward without a limit and the
+  schema accepts anything; `relativeDayLabel` already has a "Mañana" branch, so this was known. A
+  transaction dated in 2030 enters the balance and captures `lastUsedAccountId`, which orders by
+  `date DESC`. Decide whether the cap belongs in the picker, in `CreateTransactionUseCase`, or
+  nowhere.
+- [x] **12. `DateUtils` was a static object reading the ambient clock and zone**, unreachable from
+  tests and living under `hh.transaction` while half the app used it. Deleted; its clock-free parts
+  are `hh/shared/DayLabels.kt`. → **#71**
+- [x] **13. Stale documentation on `SpanishDateFormat`** — it pointed at a test in `:app`, a module
+  that no longer exists, and described a Compose Multiplatform setup that was retired. → **#73**
+
+## What was already right
+
+Worth keeping in view, because these are the patterns the fixes above copied:
+
+- `DateAndTimeCombiner` — the "why" is in the kdoc, `combineKeepingTimeOf` is idempotent, and the
+  tests run on both sides of UTC (`America/Lima`, `Asia/Karachi`).
+- `YearMonth` / `MonthRange` — month bounds are half-open and computed in Kotlin, never in SQL, with
+  the comment explaining why that matters for anyone off UTC.
+- `DayGroup` — takes `today` as an input rather than reading a clock. This is the shape the rest of
+  the date code was moved to.
+- `RecurringDueRules.periodKey` — zero-padded so string order matches chronological order, and
+  `parsePeriodKey` treats the stored value as untrusted because it arrives from other devices.
+- `ConflictResolver` — does not consult a clock where it does not need one, and says why.

--- a/docs/DATE_AUDIT.md
+++ b/docs/DATE_AUDIT.md
@@ -45,19 +45,19 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   `GetHomeDataUseCase` and the `TransactionUi` read path all resolve days through
   `TimeZone.currentSystemDefault()`. The clock can be faked in tests; the zone cannot, so no test can
   cover a month boundary in another zone. *Partially closed:* the transaction write path and the
-  frequency-window use cases take an injected `TimeZone` (#71, #73).
+  frequency-window use cases take an injected `TimeZone` (#71, #74).
 
 - [x] **8. A "last 90 days" window measured in fixed milliseconds.** `now - days * 24h` is a
   duration, not a number of days; it drifts by an hour across a DST change and starts mid-morning
-  otherwise. Duplicated in two use cases. → **#73**
+  otherwise. Duplicated in two use cases. → **#74**
 
 ## P2 — consistency and hardening
 
 - [x] **9. Deprecated `kotlinx.datetime.Instant`** in four `data/sync` files while the rest of the
-  repo used `kotlin.time.Instant`. → **#73**
+  repo used `kotlin.time.Instant`. → **#74**
 - [x] **10. `Instant.parse` on server input with no guard**, inside the per-page database
   transaction. The class guarded a *missing* `server_updated_at` but not an unreadable one, so a
-  malformed value took down the whole pull. → **#73**
+  malformed value took down the whole pull. → **#74**
 - [ ] **11. Nothing guards a future date.** The picker navigates forward without a limit and the
   schema accepts anything; `relativeDayLabel` already has a "Mañana" branch, so this was known. A
   transaction dated in 2030 enters the balance and captures `lastUsedAccountId`, which orders by
@@ -67,7 +67,7 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   tests and living under `hh.transaction` while half the app used it. Deleted; its clock-free parts
   are `hh/shared/DayLabels.kt`. → **#71**
 - [x] **13. Stale documentation on `SpanishDateFormat`** — it pointed at a test in `:app`, a module
-  that no longer exists, and described a Compose Multiplatform setup that was retired. → **#73**
+  that no longer exists, and described a Compose Multiplatform setup that was retired. → **#74**
 
 ## What was already right
 

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/shared/DateWindowTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/shared/DateWindowTest.kt
@@ -1,0 +1,83 @@
+package com.emm.domain.shared
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * The "last N days" window the frequent-category and frequent-combo suggestions are read over.
+ *
+ * It used to be `now - days * 24h`, which is a duration, not a number of days. Those two only agree
+ * in a zone that never shifts its offset.
+ */
+class DateWindowTest {
+
+    /** No DST — Peru has not observed it since 1994. The app's home zone. */
+    private val lima = TimeZone.of("America/Lima")
+
+    /** DST twice a year. Where the fixed-millis arithmetic came apart. */
+    private val madrid = TimeZone.of("Europe/Madrid")
+
+    private fun clockAt(date: LocalDate, hour: Int, minute: Int, zone: TimeZone): Clock = object : Clock {
+        override fun now(): Instant = LocalDateTime(date, LocalTime(hour, minute)).toInstant(zone)
+    }
+
+    @Test
+    fun `the window starts at local midnight, whatever time of day it is asked`() {
+        val today = LocalDate(2026, Month.AUGUST, 11)
+        val expected = LocalDate(2026, Month.MAY, 13).atStartOfDayIn(lima).toEpochMilliseconds()
+
+        // 90 days back from 11 August is 13 May, and the hour the question is asked cannot move it.
+        assertEquals(expected, startOfDayDaysAgo(90, clockAt(today, 0, 1, lima), lima))
+        assertEquals(expected, startOfDayDaysAgo(90, clockAt(today, 23, 59, lima), lima))
+    }
+
+    @Test
+    fun `a window spanning a DST change counts calendar days, not fixed hours`() {
+        // Madrid moved to CEST on 29 March 2026. A 90-day window ending 1 May crosses it, so the
+        // day 90 days back is an hour longer ago than 90 * 24h — and the naive arithmetic lands an
+        // hour into 31 January rather than at its start.
+        val clock = clockAt(LocalDate(2026, Month.MAY, 1), hour = 12, minute = 0, zone = madrid)
+        val expected = LocalDate(2026, Month.JANUARY, 31).atStartOfDayIn(madrid).toEpochMilliseconds()
+
+        assertEquals(expected, startOfDayDaysAgo(90, clock, madrid))
+
+        val naive = clock.now().toEpochMilliseconds() - 90L * 24 * 60 * 60 * 1000
+        assertNotEquals(naive, startOfDayDaysAgo(90, clock, madrid))
+    }
+
+    @Test
+    fun `a zone without DST agrees with the fixed-hours arithmetic at midnight`() {
+        // Lima never shifts, so the two only ever differ by the time of day — the property that let
+        // the old code look correct from Peru.
+        val clock = clockAt(LocalDate(2026, Month.AUGUST, 11), hour = 0, minute = 0, zone = lima)
+        val naive = clock.now().toEpochMilliseconds() - 90L * 24 * 60 * 60 * 1000
+
+        assertEquals(naive, startOfDayDaysAgo(90, clock, lima))
+    }
+
+    @Test
+    fun `a zero-day window starts at the beginning of today`() {
+        val clock = clockAt(LocalDate(2026, Month.AUGUST, 11), hour = 16, minute = 30, zone = lima)
+        val expected = LocalDate(2026, Month.AUGUST, 11).atStartOfDayIn(lima).toEpochMilliseconds()
+
+        assertEquals(expected, startOfDayDaysAgo(0, clock, lima))
+    }
+
+    @Test
+    fun `the window crosses a year boundary`() {
+        val clock = clockAt(LocalDate(2026, Month.FEBRUARY, 10), hour = 9, minute = 0, zone = lima)
+        val expected = LocalDate(2025, Month.NOVEMBER, 12).atStartOfDayIn(lima).toEpochMilliseconds()
+
+        assertEquals(expected, startOfDayDaysAgo(90, clock, lima))
+    }
+}

--- a/domain/src/commonMain/kotlin/com/emm/domain/shared/DateExtensions.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/shared/DateExtensions.kt
@@ -1,5 +1,23 @@
 package com.emm.domain.shared
 
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.minus
+import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 
 fun currentTimeInMillis(): Long = Clock.System.now().toEpochMilliseconds()
+
+/**
+ * Epoch millis at the start of the day [days] calendar days before today in [zone] — the inclusive
+ * lower bound of a "last N days" window.
+ *
+ * Counted in days rather than as `now - days * 24h`. Those are different questions and only agree
+ * in a zone that never shifts its offset: a window spanning a DST change is an hour off, and one
+ * asked at 4 p.m. otherwise starts at 4 p.m. on its first day and silently drops that morning.
+ */
+fun startOfDayDaysAgo(days: Int, clock: Clock = Clock.System, zone: TimeZone = TimeZone.currentSystemDefault()): Long {
+    val today = clock.now().toLocalDateTime(zone).date
+    return today.minus(days, DateTimeUnit.DAY).atStartOfDayIn(zone).toEpochMilliseconds()
+}

--- a/domain/src/commonMain/kotlin/com/emm/domain/transaction/GetFrequentCombosUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/transaction/GetFrequentCombosUseCase.kt
@@ -1,20 +1,25 @@
 package com.emm.domain.transaction
 
-import com.emm.domain.shared.currentTimeInMillis
+import com.emm.domain.shared.startOfDayDaysAgo
+import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
 
-class GetFrequentCombosUseCase(private val transactionStatsRepository: TransactionStatsRepository) {
+class GetFrequentCombosUseCase(
+    private val transactionStatsRepository: TransactionStatsRepository,
+    private val clock: Clock = Clock.System,
+    private val zone: TimeZone = TimeZone.currentSystemDefault(),
+) {
     suspend operator fun invoke(
         type: TransactionType,
         windowDays: Int = WINDOW_DAYS,
         limit: Int = DEFAULT_LIMIT,
     ): List<FrequentCombo> {
-        val startInclusive = currentTimeInMillis() - windowDays.toLong() * MILLIS_PER_DAY
+        val startInclusive = startOfDayDaysAgo(windowDays, clock, zone)
         return transactionStatsRepository.topUsedCombos(type, startInclusive, limit)
     }
 
     private companion object {
         const val WINDOW_DAYS = 90
         const val DEFAULT_LIMIT = 5
-        const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
     }
 }

--- a/domain/src/commonMain/kotlin/com/emm/domain/transaction/GetTopUsedCategoryIdsUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/transaction/GetTopUsedCategoryIdsUseCase.kt
@@ -1,21 +1,26 @@
 package com.emm.domain.transaction
 
 import com.emm.domain.shared.CategoryId
-import com.emm.domain.shared.currentTimeInMillis
+import com.emm.domain.shared.startOfDayDaysAgo
+import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
 
-class GetTopUsedCategoryIdsUseCase(private val transactionStatsRepository: TransactionStatsRepository) {
+class GetTopUsedCategoryIdsUseCase(
+    private val transactionStatsRepository: TransactionStatsRepository,
+    private val clock: Clock = Clock.System,
+    private val zone: TimeZone = TimeZone.currentSystemDefault(),
+) {
     suspend operator fun invoke(
         type: TransactionType,
         windowDays: Int = WINDOW_DAYS,
         limit: Int = DEFAULT_LIMIT,
     ): List<CategoryId> {
-        val startInclusive = currentTimeInMillis() - windowDays.toLong() * MILLIS_PER_DAY
+        val startInclusive = startOfDayDaysAgo(windowDays, clock, zone)
         return transactionStatsRepository.topUsedCategoryIds(type, startInclusive, limit)
     }
 
     private companion object {
         const val WINDOW_DAYS = 90
         const val DEFAULT_LIMIT = 6
-        const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
     }
 }

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/shared/SpanishDateFormat.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/shared/SpanishDateFormat.kt
@@ -6,11 +6,16 @@ import kotlinx.datetime.Month
 import kotlinx.datetime.number
 
 /**
- * Hand-rolled Spanish (es / es-PE) date and number formatting for Compose Multiplatform
- * commonMain. Replaces the JVM `java.time.format.DateTimeFormatter` + `java.text.*` localized
- * formatters that cannot run on iOS. The app is Spanish-only, so the locale tables are hardcoded
- * to match — byte-for-byte — the strings the JVM `es`/`es-PE` formatters produced (verified on the
- * build JDK). See `SpanishDateFormatTest` in `:app` for the golden assertions.
+ * Hand-rolled Spanish (es / es-PE) date formatting for `commonMain`. Replaces the JVM
+ * `java.time.format.DateTimeFormatter` + `java.text.*` localized formatters, which cannot run on
+ * iOS and would leak `java.*` into the exported framework. The app is Spanish-only, so the locale
+ * tables are hardcoded to match — byte-for-byte — the strings the JVM `es`/`es-PE` formatters
+ * produced (verified on the build JDK); `SpanishFormatGoldenTest` in this module's `commonTest`
+ * holds those assertions.
+ *
+ * **This is the only Spanish month table in the app.** A second one lived in `MonthLabels.kt` and
+ * the two disagreed on the screen for months; every label there delegates here now, and
+ * `MonthLabelsTest` fails the build if that stops being true.
  */
 object SpanishDateFormat {
 


### PR DESCRIPTION
> Independent of #71 and #72 — branched from `trunk`, and touches no file either of them does.
> Merge order does not matter.

The tail of the date audit: the three findings that needed no design decision, plus the tracker for
the ones that do.

## `docs/DATE_AUDIT.md`

Thirteen findings, what closed each, and what is still open. It exists because five were already
closed and three more land here, and a list that lives only in a chat log is a list nobody reads.

The one worth knowing before touching dates is **#5**: the schema stores an instant where the app
means a calendar day. It does not break on one device — it breaks when two devices in different
zones sync, because a transaction recorded at 23:30 in Lima is a different day in Madrid, and at a
month boundary it changes which month the Reporte counts it in. LWW does not help; it is not a
conflict. That one needs a product decision and a migration, so it is not in here.

`docs/` is an allowlist in `.gitignore`, so the file needs its own negation line to be tracked.

## Finding 8 — the frequency window was measured in fixed milliseconds

The 90-day window behind the frequent-category and frequent-combo chips was `now - days * 24h`.
That is a duration, not a number of days, and the two only agree in a zone that never shifts its
offset. Two silent consequences:

| | effect |
|---|---|
| window spans a DST change | an hour off — invisible from Peru, which dropped DST in 1994, but this core ships to iOS too |
| asked at 4 p.m. | window started at 4 p.m. on its first day and dropped that morning |

`startOfDayDaysAgo()` counts calendar days and lands on local midnight. Both use cases take an
injected `Clock` and `TimeZone`, so the boundary is testable at all for the first time —
`DateWindowTest` asserts the Madrid case *against* the arithmetic it replaces, so the test fails if
anyone puts the multiplication back.

## Finding 10 — an unreadable server timestamp took down the whole pull

`parseServerInstant` was a bare `Instant.parse` over a value that arrives from the server, and it
runs **inside the per-page database transaction** in `BaseTableSync`. One malformed
`server_updated_at` threw there and killed the entire pull rather than skipping the row.

The asymmetry was already sitting in the file: the class guards a *missing* `server_updated_at`,
logs it, and holds the cursor — but a present-and-unreadable one had no guard at all.

It returns null now, and both callers fold it into handling they already have:

- `BaseTableSync` logs the pk and sets `skippedRows`, which holds the cursor so the next cycle
  re-pulls the window.
- `overlapCursor` returns null — start from the beginning. A full re-pull is idempotent under LWW,
  whereas a stored cursor the client cannot parse would wedge sync permanently.

The high-water mark moved into a small named type on the way, so the parse, the comparison and the
unreadable case stay out of the row loop. That loop is complexity-capped and reads one branch per
policy decision; the guard would have pushed it over.

## Finding 13 — stale documentation on `SpanishDateFormat`

It pointed at `SpanishDateFormatTest` in `:app`, a module the KMP migration renamed away, when the
golden assertions are in this module's own `commonTest` as `SpanishFormatGoldenTest`. It also
described the file as serving Compose Multiplatform, retired when `:ui-android` moved to Google's
Compose.

Now it also states outright that this is the only Spanish month table — a second one existing is
what made the app spell September two ways on the same screen (#71).

Finding 9 (deprecated `kotlinx.datetime.Instant` in three `data/sync` files) rides along with 10,
since it is the same files.

## Verification

`./gradlew qualityGate` passes, iOS compile included. 5 new assertions in `DateWindowTest`, 2 more
in `SyncCursorUtilsTest` for the malformed-input paths; that suite's existing offset tests are
untouched, as its header asks.

No emulator run: none of this is reachable from the UI. The frequency window only reorders
suggestion chips, and the cursor guard needs a malformed server value to observe.

## Still open after this

`docs/DATE_AUDIT.md` carries the full list. In short: **#5** (instant vs calendar day — needs a
decision and a migration), **#6** (`currentTimeInMillis()` in entity default arguments, 19 sites),
**#7** (the timezone is still ambient on the read path), **#11** (nothing caps a future date).
