### PR TITLE
fix(report): read Reporte's month in the injected zone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,11 @@ CMP Gradle plugin is applied nowhere. `:presentation` still uses JetBrains' mult
 - `adr/` — filenames state the decision; 004 amends 002, 005 supersedes 003's frozen-UI scope.
 - `kmp/ORCHESTRATION.md` — slice workflow + ledger. `sync/PLAN.md`, `swiftui/PLAN.md` — slice status.
 - `DATE_AUDIT.md` — the 13 date-handling findings and what closed each. Read before touching dates.
-  Twelve are closed; #5 (the schema stored an instant where the app meant a calendar day) took a
-  destructive migration to schema v4 and left one follow-up — the sync wire still carries millis.
-  #7 is partial: Reporte still reads the ambient timezone where Home and Movimientos take it injected.
+  All are closed, with two follow-ups: #5 (the schema stored an instant where the app meant a
+  calendar day) took a destructive migration to schema v4 and the sync wire still carries millis,
+  and #7 left a sweep. #7's rule is the live one — whatever asks "what day/month is it" takes both
+  a `Clock` and a `TimeZone`, injected. Reporte is the only corner where they carry no default yet;
+  everywhere else the default is still the ambient read, which is the sweep #7 records.
 - `PLAY_ADVERTISING_ID.md` — the app does not use the advertising ID, with the commands that prove
   it on any AAB. Read before answering Play's declaration; the console currently says "Yes", wrongly.
 - `DESIGN_SYSTEM.md` — tokens and components (its paths still point at the pre-KMP `app/` module).

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
@@ -8,6 +8,7 @@ import com.emm.domain.report.GetSavingsRateUseCase
 import com.emm.domain.report.GetTopCategoriesOverMonthsUseCase
 import com.emm.domain.report.MonthlyComparison
 import com.emm.domain.report.MonthlySectionStats
+import com.emm.domain.report.MonthlyTotal
 import com.emm.domain.report.SavingsRate
 import com.emm.domain.shared.CategoryId
 import com.emm.domain.shared.Money
@@ -204,6 +205,43 @@ class ReportViewModelTest {
         assertFalse(vm.state.value.isCurrentMonth, "the Tendencias reload must re-read it too")
         assertEquals(YearMonth(2026, Month.SEPTEMBER), vm.state.value.month, "the month must not move")
     }
+
+    @Test
+    fun `a month rollover moves the trends bar marker, not just the pill`() = runTest(testDispatcher) {
+        // TodayPill is not the only thing keyed to "which month is now": MonthlyBarItem.isCurrentMonth
+        // draws one bar of the Tendencias chart bold. It comes off the same clock read, so it carries
+        // the same limit — and a limit disclosed for only one of its two symptoms is how this audit
+        // misled us once already. Both symptoms are now covered by a test.
+        val august = YearMonth(2026, Month.AUGUST)
+        val september = YearMonth(2026, Month.SEPTEMBER)
+        stubEmptyReport()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate().copy(
+            monthly = listOf(monthlyTotal(august), monthlyTotal(september)),
+        )
+        val clock = MovingClock(Instant.parse("2026-08-31T12:00:00Z"))
+
+        val vm = buildViewModel(clock, TimeZone.UTC)
+        advanceUntilIdle()
+        assertEquals(
+            listOf(true, false),
+            vm.state.value.trends.monthlyBars.map { it.isCurrentMonth },
+            "on 31 August the August bar is the marked one",
+        )
+
+        // Midnight passes with the screen open and the month untouched.
+        clock.instant = Instant.parse("2026-09-01T12:00:00Z")
+        vm.onIntent(ReportIntent.SelectTab(ReportTab.Tendencias))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(false, true),
+            vm.state.value.trends.monthlyBars.map { it.isCurrentMonth },
+            "the Tendencias reload must re-read the clock, or the chart keeps bolding August",
+        )
+    }
+
+    private fun monthlyTotal(month: YearMonth) =
+        MonthlyTotal(yearMonth = month, income = Money.Zero, expense = Money.Zero)
 
     /** A clock the test can move, so a month boundary can pass under a running ViewModel. */
     private class MovingClock(var instant: Instant) : Clock {

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
@@ -56,18 +56,16 @@ class ReportViewModelTest {
 
     private val currentMonth = YearMonth(2026, Month.MAY)
 
-    private fun buildViewModel(
-        clock: Clock = fixedClock,
-        zone: TimeZone = TimeZone.UTC,
-    ): ReportViewModel = ReportViewModel(
-        getMonthlyAmountByCategory = getMonthlyAmountByCategory,
-        getMonthlyComparison = getMonthlyComparison,
-        getMonthlySectionStats = getMonthlySectionStats,
-        getSavingsRate = getSavingsRate,
-        getTopCategories = getTopCategories,
-        clock = clock,
-        zone = zone,
-    )
+    private fun buildViewModel(clock: Clock = fixedClock, zone: TimeZone = TimeZone.UTC): ReportViewModel =
+        ReportViewModel(
+            getMonthlyAmountByCategory = getMonthlyAmountByCategory,
+            getMonthlyComparison = getMonthlyComparison,
+            getMonthlySectionStats = getMonthlySectionStats,
+            getSavingsRate = getSavingsRate,
+            getTopCategories = getTopCategories,
+            clock = clock,
+            zone = zone,
+        )
 
     /** Returns a minimal SavingsRate with no data months. */
     private fun emptySavingsRate(): SavingsRate = SavingsRate(

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/report/ReportViewModelTest.kt
@@ -15,6 +15,7 @@ import com.emm.domain.shared.YearMonth
 import com.emm.domain.transaction.TransactionType
 import com.emm.justchill.MainDispatcherRule
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
@@ -22,10 +23,16 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.asTimeZone
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class ReportViewModelTest {
 
@@ -40,12 +47,25 @@ class ReportViewModelTest {
     private val getSavingsRate = mockk<GetSavingsRateUseCase>()
     private val getTopCategories = mockk<GetTopCategoriesOverMonthsUseCase>()
 
-    private fun buildViewModel(): ReportViewModel = ReportViewModel(
+    // Mid-month noon UTC: YearMonth.current(fixedClock, zone) is May 2026 in every timezone, so no
+    // test below depends on where the machine running it happens to be.
+    private val fixedClock: Clock = object : Clock {
+        override fun now(): Instant = Instant.parse("2026-05-15T12:00:00Z")
+    }
+
+    private val currentMonth = YearMonth(2026, Month.MAY)
+
+    private fun buildViewModel(
+        clock: Clock = fixedClock,
+        zone: TimeZone = TimeZone.UTC,
+    ): ReportViewModel = ReportViewModel(
         getMonthlyAmountByCategory = getMonthlyAmountByCategory,
         getMonthlyComparison = getMonthlyComparison,
         getMonthlySectionStats = getMonthlySectionStats,
         getSavingsRate = getSavingsRate,
         getTopCategories = getTopCategories,
+        clock = clock,
+        zone = zone,
     )
 
     /** Returns a minimal SavingsRate with no data months. */
@@ -63,8 +83,8 @@ class ReportViewModelTest {
         coEvery { getMonthlyAmountByCategory(any(), any()) } returns emptyList()
         coEvery { getMonthlyComparison(any(), any()) } returns null
         coEvery { getMonthlySectionStats(any(), any()) } returns MonthlySectionStats(0, Money.Zero)
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
     }
 
     // ── Init smoke test ───────────────────────────────────────────────────
@@ -75,8 +95,119 @@ class ReportViewModelTest {
         val vm = buildViewModel()
         advanceUntilIdle()
 
-        assertEquals(YearMonth.current(), vm.state.value.month)
+        assertEquals(currentMonth, vm.state.value.month)
         assertEquals(TransactionType.Income, vm.state.value.selectedType)
+    }
+
+    // ── Timezone ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `the month it opens on is read in the injected zone, not the device's`() = runTest(testDispatcher) {
+        // One instant, two zones, two different months: 2026-09-01T02:00Z is already September at
+        // UTC and still 31 August at UTC-5. Which month Reporte opens on is therefore a question
+        // about the zone, and the zone that answers it has to be the injected one — a zone read off
+        // the machine is a zone no test can put a boundary on, which is how a user near a month
+        // boundary could see a different month than the data says.
+        //
+        // Both zones are asserted because one proves nothing: on a machine whose own clock sits in
+        // that zone the ambient read agrees, and the test stays green straight through the bug.
+        // The dev machine here is America/Lima, which is exactly UTC-5.
+        stubEmptyReport()
+        val nearMidnight: Clock = object : Clock {
+            override fun now(): Instant = Instant.parse("2026-09-01T02:00:00Z")
+        }
+
+        val atLima = buildViewModel(nearMidnight, UtcOffset(hours = -5).asTimeZone())
+        advanceUntilIdle()
+        assertEquals(YearMonth(2026, Month.AUGUST), atLima.state.value.month)
+
+        val atUtc = buildViewModel(nearMidnight, UtcOffset(hours = 0).asTimeZone())
+        advanceUntilIdle()
+        assertEquals(YearMonth(2026, Month.SEPTEMBER), atUtc.state.value.month)
+    }
+
+    @Test
+    fun `the trends window is asked for in the injected zone too`() = runTest(testDispatcher) {
+        // Half a screen answering for the device and half for the injection is the same defect at a
+        // smaller scale: the Tendencias window has to end on the month the rest of the screen shows.
+        stubEmptyReport()
+        val zone = UtcOffset(hours = -5).asTimeZone()
+
+        buildViewModel(fixedClock, zone)
+        advanceUntilIdle()
+
+        coVerify { getSavingsRate(fixedClock, zone, any()) }
+        coVerify { getTopCategories(any(), fixedClock, zone, any(), any()) }
+    }
+
+    @Test
+    fun `state says whether the shown month is the current one`() = runTest(testDispatcher) {
+        // The screen used to answer this itself, with an ambient YearMonth.current(). Compose has
+        // no injected zone to ask, so the "Hoy" pill was the one part of Reporte that could still
+        // disagree with the month next to it.
+        stubEmptyReport()
+        val vm = buildViewModel()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.isCurrentMonth, "The month it opens on IS the current one")
+
+        vm.onIntent(ReportIntent.PreviousMonth)
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isCurrentMonth)
+
+        vm.onIntent(ReportIntent.JumpToCurrent)
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isCurrentMonth)
+
+        // The month picker is a third way in, and it can land on any month — including this one.
+        vm.onIntent(ReportIntent.SelectMonth(YearMonth(2024, Month.MARCH)))
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isCurrentMonth)
+
+        vm.onIntent(ReportIntent.SelectMonth(currentMonth))
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isCurrentMonth, "Picking the current month is not a special case")
+    }
+
+    @Test
+    fun `a month rollover corrects isCurrentMonth with no month move`() = runTest(testDispatcher) {
+        // The check this replaced lived in Compose, where recomposition re-evaluated it for free.
+        // A flag written into state has no such refresh: computed once when the screen opened, it
+        // would keep calling August the current month after midnight on 1 September, and TodayPill
+        // — the only one-tap way back — would stay suppressed for the rest of the session.
+        //
+        // So every path that refreshes state re-reads the clock, not only a user-initiated move.
+        stubEmptyReport()
+        val clock = MovingClock(Instant.parse("2026-08-31T12:00:00Z"))
+
+        val vm = buildViewModel(clock, TimeZone.UTC)
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isCurrentMonth, "August IS the current month on 31 August")
+
+        // Midnight passes. The user has touched nothing; the shown month must not move on its own.
+        clock.instant = Instant.parse("2026-09-01T12:00:00Z")
+
+        // The Mes reload draws the pill, so it is the load-bearing path.
+        vm.onIntent(ReportIntent.SelectType(TransactionType.Spend))
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isCurrentMonth, "the Mes reload must re-read the clock")
+        assertEquals(YearMonth(2026, Month.AUGUST), vm.state.value.month, "the month must not move")
+
+        // Back to a state where the flag is true, to prove the Tendencias reload independently.
+        vm.onIntent(ReportIntent.JumpToCurrent)
+        advanceUntilIdle()
+        assertTrue(vm.state.value.isCurrentMonth)
+
+        clock.instant = Instant.parse("2026-10-01T12:00:00Z")
+        vm.onIntent(ReportIntent.SelectTab(ReportTab.Tendencias))
+        advanceUntilIdle()
+        assertFalse(vm.state.value.isCurrentMonth, "the Tendencias reload must re-read it too")
+        assertEquals(YearMonth(2026, Month.SEPTEMBER), vm.state.value.month, "the month must not move")
+    }
+
+    /** A clock the test can move, so a month boundary can pass under a running ViewModel. */
+    private class MovingClock(var instant: Instant) : Clock {
+        override fun now(): Instant = instant
     }
 
     // ── Month navigation ──────────────────────────────────────────────────
@@ -119,7 +250,7 @@ class ReportViewModelTest {
         vm.onIntent(ReportIntent.JumpToCurrent)
         advanceUntilIdle()
 
-        assertEquals(YearMonth.current(), vm.state.value.month)
+        assertEquals(currentMonth, vm.state.value.month)
     }
 
     @Test
@@ -170,7 +301,7 @@ class ReportViewModelTest {
         // The pill renders a leading ArrowUpward/ArrowDownward from deltaIsPositive. A glyph in
         // the text too showed the user "↓ ↓ 10 pts".
         stubEmptyReport()
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate().copy(
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate().copy(
             currentRatePercent = 20,
             deltaPointsVsPrior = -10,
         )
@@ -185,7 +316,7 @@ class ReportViewModelTest {
     @Test
     fun `an improving delta reports the magnitude and a positive direction`() = runTest(testDispatcher) {
         stubEmptyReport()
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate().copy(
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate().copy(
             currentRatePercent = 40,
             deltaPointsVsPrior = 7,
         )
@@ -208,8 +339,8 @@ class ReportViewModelTest {
         coEvery { getMonthlyAmountByCategory(any(), TransactionType.Spend) } returns emptyList()
         coEvery { getMonthlyComparison(any(), any()) } returns null
         coEvery { getMonthlySectionStats(any(), any()) } returns MonthlySectionStats(1, Money(450_000L))
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
 
         val vm = buildViewModel()
         advanceUntilIdle()
@@ -227,8 +358,8 @@ class ReportViewModelTest {
         coEvery { getMonthlyAmountByCategory(any(), any()) } returns emptyList()
         coEvery { getMonthlyComparison(any(), any()) } returns null
         coEvery { getMonthlySectionStats(any(), any()) } returns MonthlySectionStats(0, Money.Zero)
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
 
         val vm = buildViewModel()
         advanceUntilIdle()
@@ -246,8 +377,8 @@ class ReportViewModelTest {
             absoluteDelta = Money(20_00L),
         )
         coEvery { getMonthlySectionStats(any(), any()) } returns MonthlySectionStats(0, Money.Zero)
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
 
         val vm = buildViewModel()
         advanceUntilIdle()
@@ -299,8 +430,8 @@ class ReportViewModelTest {
         }
         coEvery { getMonthlyComparison(any(), any()) } returns null
         coEvery { getMonthlySectionStats(any(), any()) } returns MonthlySectionStats(0, Money.Zero)
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
 
         val vm = buildViewModel()
         // init triggers reloadReport — it will suspend at gate.await()
@@ -380,8 +511,8 @@ class ReportViewModelTest {
     @Test
     fun `use case error emits ShowError effect`() = runTest(testDispatcher) {
         coEvery { getMonthlyAmountByCategory(any(), any()) } throws RuntimeException("db error")
-        coEvery { getSavingsRate(any()) } returns emptySavingsRate()
-        coEvery { getTopCategories(any(), any(), any()) } returns emptyList()
+        coEvery { getSavingsRate(any(), any(), any()) } returns emptySavingsRate()
+        coEvery { getTopCategories(any(), any(), any(), any(), any()) } returns emptyList()
 
         val vm = buildViewModel()
         val effects = mutableListOf<ReportEffect>()

--- a/docs/DATE_AUDIT.md
+++ b/docs/DATE_AUDIT.md
@@ -72,10 +72,12 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   the zone and the month window would not notice; `YearMonth.current`'s `timeZone` parameter
   defaults to the ambient zone, and the default was being taken.
 
-  **Reporte closed last, and the interesting part is what it cost.** `ReportViewModel` now takes the
-  same `clock` and `zone` its two neighbours do — with no defaults on either — and its four
-  `YearMonth.current()` calls take both.
-  That alone would have been cosmetic: `GetSavingsRateUseCase` and `GetTopCategoriesOverMonthsUseCase`
+  **Reporte closed last, and the interesting part is what it cost.** `ReportViewModel` now takes an
+  injected `clock` and `zone`, as `HomeViewModel` and `SeeTransactionsViewModel` already did, and
+  its four `YearMonth.current()` calls take both. Reporte then goes one step further than those two:
+  its `clock` and `zone` have **no defaults at all**. Home and Movimientos still default theirs —
+  that gap is the follow-up recorded at the end of this finding.
+  Injecting alone would have been cosmetic: `GetSavingsRateUseCase` and `GetTopCategoriesOverMonthsUseCase`
   each accepted a `Clock` and then resolved the window's end month through the ambient zone anyway,
   so a test could fake the clock and still not say which month a report covered. Both now take a
   `zone` beside the `clock` — and **neither parameter keeps a default**. An ambient default is the
@@ -96,16 +98,22 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   Written once at open, it would have kept calling August the current month after midnight on
   1 September and kept the pill — the only one-tap way back — suppressed for the rest of the
   session. So **every** path that writes state re-derives it, both reloads included, not only a
-  user-initiated month move. The honest limit: that is not the same as continuously. A screen
-  sitting idle with nothing loading still will not notice a rollover until the next intent arrives.
-  Reporte has no resume hook to hang a refresh on; adding one is a separate change.
+  user-initiated month move.
+
+  The honest limit, and it applies to **two** markers, not one: `ReportUiState.isCurrentMonth`
+  behind the pill, and `MonthlyBarItem.isCurrentMonth`, which draws one bar of the Tendencias chart
+  bold. Both come off a clock read taken per load, so both refresh together and both go stale
+  together — refreshing on every state write is not the same as refreshing continuously. A screen
+  sitting idle with nothing loading will not notice a rollover until the next intent arrives.
+  Reporte has no resume hook to hang a refresh on; adding one is a separate change. Each marker has
+  its own test that moves a clock across a boundary under a running ViewModel, because a limit
+  disclosed for only one of its two symptoms is how this file misled a reader once already.
 
   What proves it: one instant, two zones, two different months. `2026-09-01T02:00Z` is already
   September at UTC and still 31 August at UTC-5, and `ReportViewModelTest`,
   `GetSavingsRateUseCaseTest` and `GetTopCategoriesOverMonthsUseCaseTest` each assert **both** — one
   zone proves nothing, because on a machine sitting in it the ambient read agrees by accident and
-  the test stays green straight through the bug. The staleness above has its own test, on a clock
-  the test moves across a boundary under a running ViewModel.
+  the test stays green straight through the bug.
 
   **Still open, and the reason this finding leaves a follow-up:** the rule now holds for
   `ReportViewModel` and the two report use cases, not for the codebase. `HomeViewModel`,

--- a/docs/DATE_AUDIT.md
+++ b/docs/DATE_AUDIT.md
@@ -3,11 +3,10 @@
 End-to-end audit of dates, from the picker down to the column, run on 2026-08-10. Thirteen findings.
 This file is the tracker; the reasoning for each fix lives in its PR.
 
-Twelve are closed; **#7 is partially closed** — Home and Movimientos take the injected timezone,
-Reporte still reads the ambient one. Two follow-ups survive: the one recorded under #5 (the sync
-wire and the Supabase column still carry the occurrence as epoch millis, because changing a column
-on a live server is a human step — nothing on the device depends on it any more), and the rest of
-#7.
+All thirteen are closed. Two follow-ups survive, both recorded in full below: the sync wire and the
+Supabase column still carry the occurrence as epoch millis (#5 — changing a column on a live server
+is a human step, and nothing on the device depends on it any more), and everything outside Reporte
+still lets its injected `Clock`/`TimeZone` fall back to an ambient default (#7).
 
 Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
 
@@ -59,7 +58,7 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   column. `:data` now takes an injected `Clock` and reads it once per write.
   `currentTimeInMillis()` is gone. → commits `f7b493b`, `6d10a8c`
 
-- [~] **7. The timezone was ambient where the clock was injected.** `YearMonth.startInclusiveMillis`,
+- [x] **7. The timezone was ambient where the clock was injected.** `YearMonth.startInclusiveMillis`,
   `GetHomeDataUseCase` and the `TransactionUi` read path all resolved days through
   `TimeZone.currentSystemDefault()`. The clock could be faked in tests; the zone could not, so no
   test could cover a month boundary in another zone.
@@ -73,12 +72,53 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   the zone and the month window would not notice; `YearMonth.current`'s `timeZone` parameter
   defaults to the ambient zone, and the default was being taken.
 
-  **Not closed: Reporte.** `ReportViewModel` takes no clock and no zone at all, so its three
-  `YearMonth.current()` calls, `GetSavingsRateUseCase`, `GetTopCategoriesOverMonthsUseCase` and
-  `ReportScreen`'s "is this the current month" check all still read the ambient zone. The three
-  `UiState.month` defaults do too, though every ViewModel overwrites them before first render. None
-  of it is wrong on a device — it is the same zone Koin injects — but it is the same untestable
-  boundary this finding is about, so the finding stays open until Reporte takes the injection.
+  **Reporte closed last, and the interesting part is what it cost.** `ReportViewModel` now takes the
+  same `clock` and `zone` its two neighbours do — with no defaults on either — and its four
+  `YearMonth.current()` calls take both.
+  That alone would have been cosmetic: `GetSavingsRateUseCase` and `GetTopCategoriesOverMonthsUseCase`
+  each accepted a `Clock` and then resolved the window's end month through the ambient zone anyway,
+  so a test could fake the clock and still not say which month a report covered. Both now take a
+  `zone` beside the `clock` — and **neither parameter keeps a default**. An ambient default is the
+  defect, not a convenience: it lets a caller read the machine without saying so, which is precisely
+  how Reporte drifted while every other caller was migrated. Deleting the defaults turned the silent
+  drift into a compile error naming the two call sites.
+
+  The wall-clock `UiState.month` defaults went with it — all three of them, in `ReportUiState`,
+  `HomeUiState` and `SeeTransactionsUiState`. A default that reads the clock is the same bug at
+  rest: it answers "which month is it" from the machine, at construction, for whoever forgot to
+  say. Deleting them made the compiler name every construction site; each now states a month — a
+  literal in tests and previews, the ViewModel's injected value in production.
+
+  `ReportScreen` also stopped computing "is this the current month" itself — Compose has no
+  injected zone to ask, so the `TodayPill` could disagree with the month printed beside it. Moving
+  the answer into `ReportUiState.isCurrentMonth` cost something that is worth writing down: the
+  Compose version was re-evaluated by recomposition for free, and a flag stored in state is not.
+  Written once at open, it would have kept calling August the current month after midnight on
+  1 September and kept the pill — the only one-tap way back — suppressed for the rest of the
+  session. So **every** path that writes state re-derives it, both reloads included, not only a
+  user-initiated month move. The honest limit: that is not the same as continuously. A screen
+  sitting idle with nothing loading still will not notice a rollover until the next intent arrives.
+  Reporte has no resume hook to hang a refresh on; adding one is a separate change.
+
+  What proves it: one instant, two zones, two different months. `2026-09-01T02:00Z` is already
+  September at UTC and still 31 August at UTC-5, and `ReportViewModelTest`,
+  `GetSavingsRateUseCaseTest` and `GetTopCategoriesOverMonthsUseCaseTest` each assert **both** — one
+  zone proves nothing, because on a machine sitting in it the ambient read agrees by accident and
+  the test stays green straight through the bug. The staleness above has its own test, on a clock
+  the test moves across a boundary under a running ViewModel.
+
+  **Still open, and the reason this finding leaves a follow-up:** the rule now holds for
+  `ReportViewModel` and the two report use cases, not for the codebase. `HomeViewModel`,
+  `SeeTransactionsViewModel`, `AddTransactionViewModel`, `EditTransactionViewModel` and
+  `ProfileViewModel` (clock only) still default their constructor parameters to the ambient ones, as
+  do `GetHomeDataUseCase`, `CreateTransactionUseCase`, `UpdateTransactionUseCase`,
+  `GetFrequentCombosUseCase`, `GetTopUsedCategoryIdsUseCase`, `GetPendingRecurringMovementsUseCase`,
+  the helpers in `DateExtensions.kt`, and `YearMonth.current` / `YearMonth.of(epochMillis)`
+  themselves — the last pair being the one that matters most, since it is what every other default
+  ultimately reaches. None of them is wrong on a device — Koin's
+  constructor DSL ignores Kotlin defaults and injects every time — but each is a place a future
+  caller can read the machine without saying so, which is exactly how Reporte drifted. Sweeping
+  them is mechanical and touches far more call sites than this change should.
 
   Still ambient, and deliberately: `DatePickerSheet` and the Compose previews, which have no
   injected clock either, and `ProfileScreen`'s last-sync stamp, which renders a real instant and is

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/report/GetSavingsRateUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/report/GetSavingsRateUseCaseTest.kt
@@ -13,6 +13,9 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.asTimeZone
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -25,7 +28,8 @@ class GetSavingsRateUseCaseTest {
     private val repository = mockk<TransactionStatsRepository>()
     private val useCase = GetSavingsRateUseCase(repository)
 
-    // Fixed clock: May 2026
+    // Fixed clock: May 2026. Mid-month noon UTC, so the window ends on May in every zone and the
+    // tests below are about totals, not about boundaries — the boundary has its own test.
     private val fixedClock: Clock = object : Clock {
         override fun now(): Instant = Instant.parse("2026-05-15T12:00:00Z")
     }
@@ -79,11 +83,32 @@ class GetSavingsRateUseCaseTest {
     }
 
     @Test
+    fun `the window ends at the month of the injected zone, not the device's`() = runTest {
+        // One instant, two zones, two different months: 2026-09-01T02:00Z is already September at
+        // UTC and still 31 August at UTC-5. Which month a report window ends on is therefore a
+        // question about the zone, and an injected clock alone cannot ask it — the zone was still
+        // being read off the machine, where no test can put it on a boundary.
+        //
+        // Both zones are asserted because one proves nothing: on a machine whose own clock sits in
+        // that zone the ambient read agrees, and the test stays green straight through the bug.
+        // The dev machine here is America/Lima, which is exactly UTC-5.
+        val nearMidnight: Clock = object : Clock {
+            override fun now(): Instant = Instant.parse("2026-09-01T02:00:00Z")
+        }
+
+        val atLima = useCase(clock = nearMidnight, zone = UtcOffset(hours = -5).asTimeZone(), months = 1)
+        val atUtc = useCase(clock = nearMidnight, zone = UtcOffset(hours = 0).asTimeZone(), months = 1)
+
+        assertEquals(YearMonth(2026, Month.AUGUST), atLima.monthly.single().yearMonth)
+        assertEquals(YearMonth(2026, Month.SEPTEMBER), atUtc.monthly.single().yearMonth)
+    }
+
+    @Test
     fun `happy path - returns correct savings rate and delta`() = runTest {
         val priorEnd = stubMonths(YearMonth(2026, Month.MAY), count = 6, income = 600_000L, expense = 400_000L)
         stubMonths(priorEnd, count = 6, income = 500_000L, expense = 400_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(33, result.currentRatePercent)
         // prior rate = (5000-4000)/5000 * 100 = 20, delta = 33 - 20 = 13
@@ -95,7 +120,7 @@ class GetSavingsRateUseCaseTest {
     fun `the whole window is read in a single round-trip, oldest month first`() = runTest {
         val ranges = slot<List<MonthRange>>()
 
-        useCase(months = 6, clock = fixedClock)
+        useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         // Two windows of six months used to mean 24 sequential suspend calls: one per month, per
         // type, per window. They are contiguous, so they are one request.
@@ -111,7 +136,7 @@ class GetSavingsRateUseCaseTest {
     fun `each range covers exactly its own calendar month`() = runTest {
         val ranges = slot<List<MonthRange>>()
 
-        useCase(months = 6, clock = fixedClock)
+        useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         coVerify { repository.monthlyAmountByCategoryForRanges(capture(ranges)) }
         ranges.captured.forEach { range ->
@@ -127,7 +152,7 @@ class GetSavingsRateUseCaseTest {
 
     @Test
     fun `returns zero rate when income is zero`() = runTest {
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(0, result.currentRatePercent)
         assertNull(result.deltaPointsVsPrior)
@@ -137,7 +162,7 @@ class GetSavingsRateUseCaseTest {
     fun `overspending reports a negative rate instead of hiding it as zero`() = runTest {
         stubMonths(YearMonth(2026, Month.MAY), count = 1, income = 100_000L, expense = 150_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         // (1000 - 1500) / 1000 = -50%. Clamping this to 0 hid the exact situation the
         // savings rate exists to surface.
@@ -148,7 +173,7 @@ class GetSavingsRateUseCaseTest {
     fun `rate reaches 100 when nothing is spent`() = runTest {
         stubMonths(YearMonth(2026, Month.MAY), count = 1, income = 100_000L, expense = 0L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(100, result.currentRatePercent)
     }
@@ -160,7 +185,7 @@ class GetSavingsRateUseCaseTest {
         // Prior 6 months: worse still, true rate -150.
         stubMonths(priorEnd, count = 6, income = 100_000L, expense = 250_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         // Both rates used to clamp to 0, so the delta read 0 — "same pace" while the user
         // had in fact cut their overspend by a third of their income.
@@ -172,14 +197,14 @@ class GetSavingsRateUseCaseTest {
     fun `null delta when prior period has no income`() = runTest {
         stubMonths(YearMonth(2026, Month.MAY), count = 6, income = 600_000L, expense = 400_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertNull(result.deltaPointsVsPrior)
     }
 
     @Test
     fun `monthly list has oldest month first`() = runTest {
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(6, result.monthly.size)
         assertEquals(Month.DECEMBER, result.monthly.first().yearMonth.month)
@@ -193,7 +218,7 @@ class GetSavingsRateUseCaseTest {
         stubMonth(may, TransactionType.Income, 60_000L)
         stubMonth(april, TransactionType.Spend, 40_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         // Reading twelve months in one call only helps if each answer is put back where it came
         // from; an off-by-one here would move a user's money between months.
@@ -208,7 +233,7 @@ class GetSavingsRateUseCaseTest {
     fun `averages divide by the whole window when every month has data`() = runTest {
         stubMonths(YearMonth(2026, Month.MAY), count = 6, income = 60_000L, expense = 40_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(6, result.monthsWithData)
         assertEquals(Money(60_000L), result.averageIncome)
@@ -219,7 +244,7 @@ class GetSavingsRateUseCaseTest {
     fun `averages divide by the months that have data, not by the window size`() = runTest {
         stubMonths(YearMonth(2026, Month.MAY), count = 1, income = 60_000L, expense = 40_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         // A user one month into the app earned 600 and spent 400 that month. Dividing by the
         // fixed 6-month window reported 100 and 66 — a sixth of reality, for everyone whose
@@ -235,7 +260,7 @@ class GetSavingsRateUseCaseTest {
         stubMonth(may, TransactionType.Spend, 40_000L)
         stubMonth(may.previous(), TransactionType.Income, 60_000L)
 
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(2, result.monthsWithData)
         assertEquals(Money(30_000L), result.averageIncome)
@@ -244,7 +269,7 @@ class GetSavingsRateUseCaseTest {
 
     @Test
     fun `averages are zero on an empty window instead of dividing by zero`() = runTest {
-        val result = useCase(months = 6, clock = fixedClock)
+        val result = useCase(clock = fixedClock, zone = TimeZone.UTC, months = 6)
 
         assertEquals(0, result.monthsWithData)
         assertEquals(Money.Zero, result.averageIncome)

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/report/GetTopCategoriesOverMonthsUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/report/GetTopCategoriesOverMonthsUseCaseTest.kt
@@ -13,6 +13,9 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.asTimeZone
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -25,6 +28,8 @@ class GetTopCategoriesOverMonthsUseCaseTest {
     private val repository = mockk<TransactionStatsRepository>()
     private val useCase = GetTopCategoriesOverMonthsUseCase(repository)
 
+    // Mid-month noon UTC: the window ends on May 2026 in every zone, so the tests below are about
+    // ranking, not about boundaries — the boundary has its own test.
     private val fixedClock: Clock = object : Clock {
         override fun now(): Instant = Instant.parse("2026-05-15T12:00:00Z")
     }
@@ -70,11 +75,45 @@ class GetTopCategoriesOverMonthsUseCaseTest {
     }
 
     @Test
+    fun `the window ends at the month of the injected zone, not the device's`() = runTest {
+        // One instant, two zones, two different months: 2026-09-01T02:00Z is already September at
+        // UTC and still 31 August at UTC-5. A one-month window therefore reads August in Lima and
+        // September at UTC — off the same clock. The zone used to come off the machine, where no
+        // test can move it onto a boundary.
+        //
+        // Both zones are asserted because one proves nothing: on a machine whose own clock sits in
+        // that zone the ambient read agrees, and the test stays green straight through the bug.
+        // The dev machine here is America/Lima, which is exactly UTC-5.
+        val nearMidnight: Clock = object : Clock {
+            override fun now(): Instant = Instant.parse("2026-09-01T02:00:00Z")
+        }
+        stubMonth(YearMonth(2026, Month.AUGUST), listOf(cat("A", 100_00L)))
+
+        val atLima = useCase(
+            TransactionType.Spend,
+            clock = nearMidnight,
+            zone = UtcOffset(hours = -5).asTimeZone(),
+            months = 1,
+            topN = 3,
+        )
+        val atUtc = useCase(
+            TransactionType.Spend,
+            clock = nearMidnight,
+            zone = UtcOffset(hours = 0).asTimeZone(),
+            months = 1,
+            topN = 3,
+        )
+
+        assertEquals(listOf(CategoryId("A")), atLima.map { it.categoryId })
+        assertTrue(atUtc.isEmpty(), "September holds no movements; got: $atUtc")
+    }
+
+    @Test
     fun `happy path - returns top 3 categories sorted by total amount`() = runTest {
         val may = YearMonth(2026, Month.MAY)
         stubMonth(may, listOf(cat("A", 500_00L), cat("B", 300_00L), cat("C", 200_00L)))
 
-        val result = useCase(TransactionType.Spend, months = 1, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 1, topN = 3)
 
         assertEquals(3, result.size)
         assertEquals(CategoryId("A"), result[0].categoryId)
@@ -86,7 +125,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
     fun `the whole window is read in a single round-trip, oldest month first`() = runTest {
         val ranges = slot<List<MonthRange>>()
 
-        useCase(TransactionType.Spend, months = 6, topN = 3, clock = fixedClock)
+        useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 6, topN = 3)
 
         coVerify(exactly = 1) { repository.monthlyAmountByCategoryForRanges(capture(ranges)) }
         assertEquals(6, ranges.captured.size)
@@ -101,7 +140,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
         stubMonth(may, listOf(cat("SPEND", 900_00L)))
         stubIncomeMonth(may, listOf(cat("INCOME", 100_00L)))
 
-        val result = useCase(TransactionType.Income, months = 1, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Income, clock = fixedClock, zone = TimeZone.UTC, months = 1, topN = 3)
 
         // One query now returns both types; picking the wrong bucket would rank a user's salary
         // as a spending category.
@@ -114,7 +153,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
         val may = YearMonth(2026, Month.MAY)
         stubMonth(may, listOf(uncategorized(900_00L), cat("A", 100_00L)))
 
-        val result = useCase(TransactionType.Spend, months = 1, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 1, topN = 3)
 
         assertEquals(1, result.size)
         assertEquals(CategoryId("A"), result.single().categoryId)
@@ -122,7 +161,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
 
     @Test
     fun `empty months returns empty list`() = runTest {
-        val result = useCase(TransactionType.Spend, months = 6, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 6, topN = 3)
 
         assertTrue(result.isEmpty())
     }
@@ -135,7 +174,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
         stubMonth(may, listOf(cat("A", 500_00L), cat("B", 300_00L)))
         stubMonth(apr, listOf(cat("A", 400_00L)))
 
-        val result = useCase(TransactionType.Spend, months = 2, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 2, topN = 3)
 
         val catA = result.first { it.categoryId == CategoryId("A") }
         val catB = result.first { it.categoryId == CategoryId("B") }
@@ -150,7 +189,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
         val may = YearMonth(2026, Month.MAY)
         stubMonth(may, listOf(cat("A", 1000_00L)))
 
-        val result = useCase(TransactionType.Spend, months = 6, topN = 3, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 6, topN = 3)
 
         assertEquals(1, result.size)
         assertEquals(Money(1000_00L), result[0].totalAmount)
@@ -163,7 +202,7 @@ class GetTopCategoriesOverMonthsUseCaseTest {
         val may = YearMonth(2026, Month.MAY)
         stubMonth(may, listOf(cat("A", 500_00L), cat("B", 400_00L), cat("C", 300_00L), cat("D", 200_00L)))
 
-        val result = useCase(TransactionType.Spend, months = 1, topN = 2, clock = fixedClock)
+        val result = useCase(TransactionType.Spend, clock = fixedClock, zone = TimeZone.UTC, months = 1, topN = 2)
 
         assertEquals(2, result.size)
     }

--- a/domain/src/commonMain/kotlin/com/emm/domain/report/GetSavingsRateUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/report/GetSavingsRateUseCase.kt
@@ -3,16 +3,23 @@ package com.emm.domain.report
 import com.emm.domain.shared.Money
 import com.emm.domain.shared.YearMonth
 import com.emm.domain.transaction.TransactionStatsRepository
+import kotlinx.datetime.TimeZone
 import kotlin.time.Clock
 
 private const val PERCENT_MULTIPLIER = 100
 
 class GetSavingsRateUseCase(private val transactionStatsRepository: TransactionStatsRepository) {
 
-    suspend operator fun invoke(months: Int = 6, clock: Clock = Clock.System): SavingsRate {
+    /**
+     * [clock] and [zone] have no defaults on purpose. "Which month is it" is a question about a
+     * place, and a default that reads the machine lets a caller answer it for the wrong one without
+     * saying so — which is exactly how Reporte ended up resolving its months against the ambient
+     * zone while every other screen took an injected one. Callers state where they are asking from.
+     */
+    suspend operator fun invoke(clock: Clock, zone: TimeZone, months: Int = 6): SavingsRate {
         // Both windows are contiguous and end at the current month, so they are one fetch:
         // the prior window is the older half of a 2 * months span.
-        val span = buildSpan(YearMonth.current(clock), months * 2)
+        val span = buildSpan(YearMonth.current(clock, zone), months * 2)
         val priorWindow = span.take(months)
         val currentWindow = span.drop(months)
 

--- a/domain/src/commonMain/kotlin/com/emm/domain/report/GetTopCategoriesOverMonthsUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/report/GetTopCategoriesOverMonthsUseCase.kt
@@ -5,17 +5,23 @@ import com.emm.domain.shared.Money
 import com.emm.domain.shared.YearMonth
 import com.emm.domain.transaction.TransactionStatsRepository
 import com.emm.domain.transaction.TransactionType
+import kotlinx.datetime.TimeZone
 import kotlin.time.Clock
 
 class GetTopCategoriesOverMonthsUseCase(private val transactionStatsRepository: TransactionStatsRepository) {
 
+    /**
+     * [clock] and [zone] have no defaults on purpose — see [GetSavingsRateUseCase.invoke]. The
+     * window ends at the month the caller's [zone] is in, not the month the machine is in.
+     */
     suspend operator fun invoke(
         type: TransactionType,
+        clock: Clock,
+        zone: TimeZone,
         months: Int = 6,
         topN: Int = 3,
-        clock: Clock = Clock.System,
     ): List<CategoryAggregate> {
-        val window = YearMonth.windowEndingAt(YearMonth.current(clock), months)
+        val window = YearMonth.windowEndingAt(YearMonth.current(clock, zone), months)
 
         // Per-month results oldest-first, fetched in one round-trip.
         // The uncategorized bucket is dropped here: this is a ranking OF categories, and a

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/home/HomeUiState.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/home/HomeUiState.kt
@@ -6,8 +6,13 @@ import com.emm.justchill.core.mvi.UiState
 import com.emm.justchill.hh.recurring.PendingRecurringUi
 import com.emm.justchill.hh.transaction.TransactionUi
 
+/**
+ * [month] carries no default. A default that reads the wall clock answers "which month is it" from
+ * the machine, for whoever forgot to say — the ambient read this whole state class exists downstream
+ * of. The ViewModel holds the injected clock and zone and supplies it; previews name one.
+ */
 data class HomeUiState(
-    val month: YearMonth = YearMonth.current(),
+    val month: YearMonth,
     val lastTransactions: List<TransactionUi> = emptyList(),
     val income: Money = Money.Zero,
     val spend: Money = Money.Zero,

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/home/HomeViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/home/HomeViewModel.kt
@@ -29,9 +29,11 @@ class HomeViewModel(
     private val zone: TimeZone = TimeZone.currentSystemDefault(),
 ) : MviViewModel<HomeUiState, HomeIntent, HomeEffect>() {
 
-    override val initialState = HomeUiState()
-
+    // Declared before initialState on purpose: property initializers run in order, so the state can
+    // only borrow the month from here if here already exists. One read, one source of truth.
     private val selectedMonth = MutableStateFlow(YearMonth.current(clock, zone))
+
+    override val initialState = HomeUiState(month = selectedMonth.value)
 
     init {
         selectedMonth

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportUiState.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportUiState.kt
@@ -4,8 +4,18 @@ import com.emm.domain.shared.YearMonth
 import com.emm.domain.transaction.TransactionType
 import com.emm.justchill.core.mvi.UiState
 
+/**
+ * [month] carries no default. A default that reads the wall clock is the same defect as an ambient
+ * timezone: it answers "which month is it" from the machine, at the moment the class is loaded, for
+ * whoever forgot to say. The ViewModel holds the injected clock and zone, so the ViewModel supplies
+ * the month — and every other construction site (previews, formatter tests) names one explicitly.
+ *
+ * [isCurrentMonth] is the answer to "is [month] the month the user is living in", computed by the
+ * ViewModel for the same reason: the screen has no injected zone to ask.
+ */
 data class ReportUiState(
-    val month: YearMonth = YearMonth.current(),
+    val month: YearMonth,
+    val isCurrentMonth: Boolean = false,
     val selectedType: TransactionType = TransactionType.Income,
     val selectedTab: ReportTab = ReportTab.Mes,
     val totalFormatted: String = "S/ 0.00",

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportViewModel.kt
@@ -45,10 +45,15 @@ class ReportViewModel(
 ) : MviViewModel<ReportUiState, ReportIntent, ReportEffect>() {
 
     override val initialState: ReportUiState = run {
-        // Both fields come off one read, so the month and the flag describing it cannot disagree.
         val opening = YearMonth.current(clock, zone)
         ReportUiState(
             month = opening,
+            // A second read of the same clock, not the same read — [isCurrent] asks again, and
+            // nothing here stops the two landing either side of midnight. Deriving it beats
+            // hardcoding `true`, which would be correct only by coincidence of the line above; and
+            // if the two reads ever did disagree the flag comes out false, which is the harmless
+            // direction: a spurious TodayPill offers a jump that is already a no-op, where a
+            // spurious `true` would hide the only one-tap way back.
             isCurrentMonth = isCurrent(opening),
             selectedType = TransactionType.Income,
         )
@@ -178,6 +183,8 @@ class ReportViewModel(
                 topN = TOP_EXPENSES_SHOWN,
             )
 
+            // Read per load, not per ViewModel: this may be the first thing to run after a month
+            // rolled over under an open screen. Feeds both the bars and the state flag below.
             val currentYm = YearMonth.current(clock, zone)
             val isEarlyState = savingsRate.monthsWithData < MONTHS_FOR_A_MEANINGFUL_TREND
 

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/report/ReportViewModel.kt
@@ -14,7 +14,9 @@ import com.emm.justchill.core.mvi.MviViewModel
 import com.emm.justchill.hh.shared.monthAbbrevLabel
 import com.emm.justchill.hh.shared.monthLabel
 import kotlinx.coroutines.Job
+import kotlinx.datetime.TimeZone
 import kotlin.math.abs
+import kotlin.time.Clock
 
 /** Window the Tendencias tab reads. Long enough to show a season, short enough to stay relevant. */
 private const val TRENDS_WINDOW_MONTHS = 6
@@ -25,16 +27,32 @@ private const val MONTHS_FOR_A_MEANINGFUL_TREND = 3
 /** How many categories the "en qué se te va" card lists. */
 private const val TOP_EXPENSES_SHOWN = 3
 
+@Suppress("LongParameterList")
 class ReportViewModel(
     private val getMonthlyAmountByCategory: GetMonthlyAmountByCategoryUseCase,
     private val getMonthlyComparison: GetMonthlyComparisonUseCase,
     private val getMonthlySectionStats: GetMonthlySectionStatsUseCase,
     private val getSavingsRate: GetSavingsRateUseCase,
     private val getTopCategories: GetTopCategoriesOverMonthsUseCase,
+    // Neither has a default, for the reason the two report use cases have none: an ambient default
+    // is a silent read of the machine. Koin's constructor DSL ignores Kotlin defaults anyway
+    // (see SharedModule), so a default here would only ever serve a hand-built instance.
+    // "Which month is it" is "what day is it" asked at a coarser grain, and a zone read off the
+    // device is one no test can move onto a month boundary — so nothing could prove which month
+    // Reporte opens on for a user sitting in another zone.
+    private val clock: Clock,
+    private val zone: TimeZone,
 ) : MviViewModel<ReportUiState, ReportIntent, ReportEffect>() {
 
-    override val initialState: ReportUiState =
-        ReportUiState(month = YearMonth.current(), selectedType = TransactionType.Income)
+    override val initialState: ReportUiState = run {
+        // Both fields come off one read, so the month and the flag describing it cannot disagree.
+        val opening = YearMonth.current(clock, zone)
+        ReportUiState(
+            month = opening,
+            isCurrentMonth = isCurrent(opening),
+            selectedType = TransactionType.Income,
+        )
+    }
 
     // Latest-wins jobs: cancels the in-flight load before starting the new one.
     private var reportJob: Job? = null
@@ -45,33 +63,20 @@ class ReportViewModel(
         reloadTrends()
     }
 
-    // Pure dispatch — exhaustiveness enforced by compiler via expression form.
+    // Pure dispatch — exhaustiveness enforced by compiler via expression form. The four month
+    // intents differ only in which month they ask for, so they go straight to [showMonth] rather
+    // than through a handler each that would forward one expression.
     override fun onIntent(intent: ReportIntent) = when (intent) {
-        ReportIntent.PreviousMonth -> onPreviousMonth()
-        ReportIntent.NextMonth -> onNextMonth()
-        ReportIntent.JumpToCurrent -> onJumpToCurrent()
+        ReportIntent.PreviousMonth -> showMonth(currentState.month.previous())
+        ReportIntent.NextMonth -> showMonth(currentState.month.next())
+        ReportIntent.JumpToCurrent -> showMonth(YearMonth.current(clock, zone))
+        is ReportIntent.SelectMonth -> showMonth(intent.month)
         is ReportIntent.SelectType -> onSelectType(intent.type)
         is ReportIntent.SelectTab -> onSelectTab(intent.tab)
-        is ReportIntent.SelectMonth -> onSelectMonth(intent.month)
         ReportIntent.ShareReport -> buildAndShareReport()
     }
 
     // ── Intent handlers ───────────────────────────────────────────────────
-
-    private fun onPreviousMonth() {
-        updateState { copy(month = month.previous()) }
-        reloadReport()
-    }
-
-    private fun onNextMonth() {
-        updateState { copy(month = month.next()) }
-        reloadReport()
-    }
-
-    private fun onJumpToCurrent() {
-        updateState { copy(month = YearMonth.current()) }
-        reloadReport()
-    }
 
     private fun onSelectType(type: TransactionType) {
         updateState { copy(selectedType = type) }
@@ -86,10 +91,26 @@ class ReportViewModel(
         }
     }
 
-    private fun onSelectMonth(month: YearMonth) {
-        updateState { copy(month = month) }
+    /** The single place the shown month changes, so `month` and its flag always move together. */
+    private fun showMonth(month: YearMonth) {
+        updateState { copy(month = month, isCurrentMonth = isCurrent(month)) }
         reloadReport()
     }
+
+    /**
+     * Whether [month] is the one the user is living in right now, off the injected clock and zone.
+     *
+     * Called from every path that writes state, not only from a month move. The check this replaced
+     * lived in Compose, where recomposition re-evaluated it for free; a flag stored in state has to
+     * be re-derived deliberately or it goes stale — a session left open across midnight on the 1st
+     * would keep calling last month the current one, and `TodayPill`, the only one-tap way back,
+     * would stay suppressed.
+     *
+     * The honest limit: "every path that writes state" is not "continuously". A screen sitting idle
+     * with nothing loading does not notice a rollover until the next intent arrives. Reporte has no
+     * resume hook to hang a refresh on, and giving it one is a separate change.
+     */
+    private fun isCurrent(month: YearMonth): Boolean = month == YearMonth.current(clock, zone)
 
     // ── Data loading (latest-wins) ────────────────────────────────────────
 
@@ -126,6 +147,9 @@ class ReportViewModel(
 
             updateState {
                 copy(
+                    // Re-read, not carried over: this load may be the first thing to happen after a
+                    // month rolled over under an open screen.
+                    isCurrentMonth = isCurrent(month),
                     totalFormatted = formatSolesWithDecimals(total.cents),
                     comparisonText = comparisonText,
                     comparisonDirectionUp = directionUp,
@@ -145,14 +169,16 @@ class ReportViewModel(
     private fun reloadTrends() {
         trendsJob?.cancel()
         trendsJob = launchSafe(onError = { e -> ReportEffect.ShowError(e.toUserMessage()) }) {
-            val savingsRate = getSavingsRate(months = TRENDS_WINDOW_MONTHS)
+            val savingsRate = getSavingsRate(clock = clock, zone = zone, months = TRENDS_WINDOW_MONTHS)
             val topExpenses = getTopCategories(
                 TransactionType.Spend,
+                clock = clock,
+                zone = zone,
                 months = TRENDS_WINDOW_MONTHS,
                 topN = TOP_EXPENSES_SHOWN,
             )
 
-            val currentYm = YearMonth.current()
+            val currentYm = YearMonth.current(clock, zone)
             val isEarlyState = savingsRate.monthsWithData < MONTHS_FOR_A_MEANINGFUL_TREND
 
             // Magnitude only. Direction is `deltaIsPositive`, which the pill turns into a leading
@@ -180,6 +206,9 @@ class ReportViewModel(
 
             updateState {
                 copy(
+                    // Same read the bars above used, so one pass cannot answer "is this the current
+                    // month" two different ways.
+                    isCurrentMonth = month == currentYm,
                     trends = TrendsUiData(
                         savingsRatePercent = savingsRate.currentRatePercent,
                         deltaText = deltaText,

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsUiState.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsUiState.kt
@@ -47,8 +47,13 @@ enum class ListDisplayState {
     Content,
 }
 
+/**
+ * [month] carries no default — see [com.emm.justchill.hh.home.HomeUiState]. A wall-clock default
+ * makes every construction site an unannounced ambient read; the ViewModel supplies the month from
+ * its injected clock and zone, and tests and previews name one.
+ */
 data class SeeTransactionsUiState(
-    val month: YearMonth = YearMonth.current(),
+    val month: YearMonth,
     val days: List<DayGroup> = emptyList(),
     val summary: MonthSummaryUi? = null,
     /**

--- a/presentation/src/commonTest/kotlin/com/emm/justchill/hh/report/ReportShareFormatterTest.kt
+++ b/presentation/src/commonTest/kotlin/com/emm/justchill/hh/report/ReportShareFormatterTest.kt
@@ -1,10 +1,16 @@
 package com.emm.justchill.hh.report
 
+import com.emm.domain.shared.YearMonth
+import kotlinx.datetime.Month
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ReportShareFormatterTest {
+
+    // Which month it is does not matter to a formatter — that it is STATED does. ReportUiState used
+    // to default it to YearMonth.current(), so these tests silently ran against the wall clock.
+    private val may2026 = YearMonth(2026, Month.MAY)
 
     // ── buildContextSentence ──────────────────────────────────────────────
 
@@ -84,21 +90,21 @@ class ReportShareFormatterTest {
 
     @Test
     fun `buildMesShareText contains JustChill footer`() {
-        val state = ReportUiState()
+        val state = ReportUiState(month = may2026)
         val result = ReportShareFormatter.buildMesShareText(state)
         assertTrue(result.contains("— JustChill"), "Footer missing from: $result")
     }
 
     @Test
     fun `buildMesShareText includes singular movimiento when count is 1`() {
-        val state = ReportUiState(movementCount = 1, averageFormatted = "S/ 500")
+        val state = ReportUiState(month = may2026, movementCount = 1, averageFormatted = "S/ 500")
         val result = ReportShareFormatter.buildMesShareText(state)
         assertTrue(result.contains("1 movimiento"), "Expected singular 'movimiento' in: $result")
     }
 
     @Test
     fun `buildMesShareText includes plural movimientos when count is not 1`() {
-        val state = ReportUiState(movementCount = 5, averageFormatted = "S/ 200")
+        val state = ReportUiState(month = may2026, movementCount = 5, averageFormatted = "S/ 200")
         val result = ReportShareFormatter.buildMesShareText(state)
         assertTrue(result.contains("5 movimientos"), "Expected plural 'movimientos' in: $result")
     }
@@ -107,7 +113,7 @@ class ReportShareFormatterTest {
 
     @Test
     fun `buildTrendsShareText contains JustChill footer`() {
-        val state = ReportUiState()
+        val state = ReportUiState(month = may2026)
         val result = ReportShareFormatter.buildTrendsShareText(state)
         assertTrue(result.contains("— JustChill"), "Footer missing from: $result")
     }
@@ -115,6 +121,7 @@ class ReportShareFormatterTest {
     @Test
     fun `buildTrendsShareText includes savings rate percent`() {
         val state = ReportUiState(
+            month = may2026,
             trends = TrendsUiData(savingsRatePercent = 35),
         )
         val result = ReportShareFormatter.buildTrendsShareText(state)
@@ -127,9 +134,11 @@ class ReportShareFormatterTest {
         // glyph. Shared text has no icon to lean on: "(10 pts vs. 6 meses previos)" would not
         // say whether the user improved or slipped.
         val worse = ReportUiState(
+            month = may2026,
             trends = TrendsUiData(savingsRatePercent = 20, deltaText = "10 pts", deltaIsPositive = false),
         )
         val better = ReportUiState(
+            month = may2026,
             trends = TrendsUiData(savingsRatePercent = 40, deltaText = "10 pts", deltaIsPositive = true),
         )
 
@@ -145,7 +154,7 @@ class ReportShareFormatterTest {
 
     @Test
     fun `buildTrendsShareText omits the delta entirely when there is no baseline`() {
-        val state = ReportUiState(trends = TrendsUiData(savingsRatePercent = 20, deltaText = null))
+        val state = ReportUiState(month = may2026, trends = TrendsUiData(savingsRatePercent = 20, deltaText = null))
         val result = ReportShareFormatter.buildTrendsShareText(state)
         assertTrue(!result.contains("6 meses previos"), "Unexpected comparison in: $result")
     }
@@ -153,6 +162,7 @@ class ReportShareFormatterTest {
     @Test
     fun `buildTrendsShareText omits Mayores gastos section when topExpenses is empty`() {
         val state = ReportUiState(
+            month = may2026,
             trends = TrendsUiData(topExpenses = emptyList()),
         )
         val result = ReportShareFormatter.buildTrendsShareText(state)

--- a/presentation/src/commonTest/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsUiStateTest.kt
+++ b/presentation/src/commonTest/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsUiStateTest.kt
@@ -1,6 +1,8 @@
 package com.emm.justchill.hh.seetransactions
 
+import com.emm.domain.shared.YearMonth
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -13,6 +15,10 @@ import kotlin.test.assertTrue
  */
 class SeeTransactionsUiStateTest {
 
+    // Stated, not read. The state used to default `month` to YearMonth.current(), which quietly
+    // made every case below depend on the day it ran; none of them is about a month at all.
+    private val august = YearMonth(2026, Month.AUGUST)
+
     private val day = DayGroup(
         date = LocalDate(2026, 8, 10),
         today = LocalDate(2026, 8, 10),
@@ -20,23 +26,23 @@ class SeeTransactionsUiStateTest {
     )
 
     @Test fun unknown_count_is_loading_not_an_empty_state() {
-        val state = SeeTransactionsUiState()
+        val state = SeeTransactionsUiState(month = august)
 
         assertEquals(ListDisplayState.Loading, state.listDisplayState)
     }
 
     @Test fun the_month_selector_shows_while_the_count_is_still_unknown() {
-        assertTrue(SeeTransactionsUiState().isMonthSelectorVisible)
+        assertTrue(SeeTransactionsUiState(month = august).isMonthSelectorVisible)
     }
 
     @Test fun the_month_selector_hides_once_a_filter_makes_the_list_cross_month() {
-        val state = SeeTransactionsUiState(movementCount = 3, query = "café")
+        val state = SeeTransactionsUiState(month = august, movementCount = 3, query = "café")
 
         assertFalse(state.isMonthSelectorVisible)
     }
 
     @Test fun a_count_known_to_be_zero_is_an_empty_ledger() {
-        val state = SeeTransactionsUiState(movementCount = 0)
+        val state = SeeTransactionsUiState(month = august, movementCount = 0)
 
         assertEquals(ListDisplayState.EmptyLedger, state.listDisplayState)
     }
@@ -45,19 +51,20 @@ class SeeTransactionsUiStateTest {
         // Previously hasNoTransactionsAtAll and hasNoResultsForFilter were both true here and only
         // the screen's `when` ordering broke the tie. A ledger with nothing in it cannot have
         // search results to miss, so the ledger state wins.
-        val state = SeeTransactionsUiState(movementCount = 0, query = "café")
+        val state = SeeTransactionsUiState(month = august, movementCount = 0, query = "café")
 
         assertEquals(ListDisplayState.EmptyLedger, state.listDisplayState)
     }
 
     @Test fun a_filter_that_matches_nothing_in_a_stocked_ledger_is_no_search_results() {
-        val state = SeeTransactionsUiState(movementCount = 12, query = "café")
+        val state = SeeTransactionsUiState(month = august, movementCount = 12, query = "café")
 
         assertEquals(ListDisplayState.NoSearchResults, state.listDisplayState)
     }
 
     @Test fun a_category_filter_alone_is_enough_to_reach_no_search_results() {
         val state = SeeTransactionsUiState(
+            month = august,
             movementCount = 12,
             activeCategory = ActiveCategoryInfo(id = "cat-1", name = "Comida"),
         )
@@ -66,19 +73,19 @@ class SeeTransactionsUiStateTest {
     }
 
     @Test fun a_stocked_ledger_with_an_empty_month_and_no_filter_is_an_empty_month() {
-        val state = SeeTransactionsUiState(movementCount = 12)
+        val state = SeeTransactionsUiState(month = august, movementCount = 12)
 
         assertEquals(ListDisplayState.EmptyMonth, state.listDisplayState)
     }
 
     @Test fun rows_render_as_content() {
-        val state = SeeTransactionsUiState(movementCount = 12, days = listOf(day))
+        val state = SeeTransactionsUiState(month = august, movementCount = 12, days = listOf(day))
 
         assertEquals(ListDisplayState.Content, state.listDisplayState)
     }
 
     @Test fun rows_that_arrive_before_the_count_still_render_as_content() {
-        val state = SeeTransactionsUiState(days = listOf(day))
+        val state = SeeTransactionsUiState(month = august, days = listOf(day))
 
         assertEquals(ListDisplayState.Content, state.listDisplayState)
     }

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/home/HomeScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/home/HomeScreen.kt
@@ -66,6 +66,7 @@ import com.emm.justchill.hh.transaction.CategoryUi
 import com.emm.justchill.hh.transaction.TransactionUi
 import com.emm.justchill.hh.transaction.components.TransactionRow
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
 
 /**
  * VM-owning overload used by [HomeEntry] in Hh.kt.
@@ -681,6 +682,7 @@ private fun HomeScreenPreview() {
     EmmTheme {
         HomeScreen(
             HomeUiState(
+                month = PREVIEW_MONTH,
                 balance = Money(48200000L),
                 income = Money(32000000L),
                 spend = Money(8400000L),
@@ -725,9 +727,12 @@ private fun HomeScreenPreview() {
 @Composable
 private fun HomeScreenEmptyPreview() {
     EmmTheme {
-        HomeScreen(HomeUiState())
+        HomeScreen(HomeUiState(month = PREVIEW_MONTH))
     }
 }
 
 /** Any fixed local datetime — previews render the pre-formatted labels, never this value. */
 private val PREVIEW_OCCURRED_AT = LocalDateTime(2026, 8, 10, 14, 30)
+
+/** Fixed, matching [PREVIEW_OCCURRED_AT]. A preview that read the clock would drift with the day. */
+private val PREVIEW_MONTH = YearMonth(2026, Month.AUGUST)

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/report/ReportScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/report/ReportScreen.kt
@@ -188,7 +188,6 @@ private fun MesContent(
     onLabelClick: () -> Unit,
 ) {
     val spacing = LocalEmmSpacing.current
-    val isCurrentMonth = state.month == YearMonth.current()
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -201,7 +200,9 @@ private fun MesContent(
             onNext = onNextMonth,
             onLabelClick = onLabelClick,
         )
-        if (!isCurrentMonth) {
+        // Answered by the ViewModel, which holds the injected clock and zone. Resolving "what month
+        // is it" here read the device instead, so the pill could disagree with the month beside it.
+        if (!state.isCurrentMonth) {
             Spacer(Modifier.size(spacing.s2))
             TodayPill(onClick = onJumpToCurrent)
         }

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/report/ReportScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/report/ReportScreen.kt
@@ -449,6 +449,9 @@ private fun ReportScreenMesPreview() {
         ReportScreen(
             state = ReportUiState(
                 month = YearMonth(2026, Month.MAY),
+                // Stated, not inherited: the default is false, which would draw TodayPill on every
+                // canvas regardless of the month above. May is this preview set's "now".
+                isCurrentMonth = true,
                 selectedType = TransactionType.Income,
                 selectedTab = ReportTab.Mes,
                 totalFormatted = "S/ 6,200.00",
@@ -487,6 +490,9 @@ private fun ReportScreenMesGastosPreview() {
         ReportScreen(
             state = ReportUiState(
                 month = YearMonth(2026, Month.MARCH),
+                // March against a "now" of May: a browsed past month, so TodayPill belongs on this
+                // canvas. The one preview that renders it.
+                isCurrentMonth = false,
                 selectedType = TransactionType.Spend,
                 selectedTab = ReportTab.Mes,
                 totalFormatted = "S/ 4,580.00",
@@ -527,6 +533,8 @@ private fun ReportScreenEmptyPreview() {
         ReportScreen(
             state = ReportUiState(
                 month = YearMonth(2026, Month.MAY),
+                // The current month, and empty — landing on a month with nothing in it yet.
+                isCurrentMonth = true,
                 selectedType = TransactionType.Income,
                 shares = emptyList(),
                 isEmpty = true,

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/seetransactions/SeeTransactionsScreen.kt
@@ -78,6 +78,7 @@ import com.emm.justchill.hh.transaction.TransactionUi
 import com.emm.justchill.hh.transaction.components.TransactionRow
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.koin.compose.viewmodel.koinViewModel
@@ -767,7 +768,7 @@ private fun SeeTransactionsEmptyPreview() {
     EmmTheme {
         SeeTransactionsContent(
             // An explicit zero: the default count is null, which is "not known yet", not "empty".
-            state = SeeTransactionsUiState(movementCount = 0L),
+            state = SeeTransactionsUiState(month = PREVIEW_MONTH, movementCount = 0L),
             onIntent = {},
             navigateToEdit = {},
         )
@@ -804,7 +805,7 @@ private fun SeeTransactionsMonthPreview() {
         }
         SeeTransactionsContent(
             state = SeeTransactionsUiState(
-                month = YearMonth.current(),
+                month = PREVIEW_MONTH,
                 days = listOf(previewDayGroup(txs)),
                 summary = MonthSummaryUi(income = Money(320_000L), spend = Money(8_420L)),
                 movementCount = 2,
@@ -835,6 +836,7 @@ private fun SeeTransactionsPopulatedPreview() {
         }
         SeeTransactionsContent(
             state = SeeTransactionsUiState(
+                month = PREVIEW_MONTH,
                 days = listOf(previewDayGroup(txs)),
                 movementCount = 1,
                 activeCategory = ActiveCategoryInfo("4", "Ocio"),
@@ -851,6 +853,7 @@ private fun SeeTransactionsNoResultsPreview() {
     EmmTheme {
         SeeTransactionsContent(
             state = SeeTransactionsUiState(
+                month = PREVIEW_MONTH,
                 days = emptyList(),
                 movementCount = 5,
                 query = "café",
@@ -869,3 +872,6 @@ private fun previewDayGroup(transactions: List<TransactionUi>): DayGroup {
 
 /** Any fixed local datetime — previews render the pre-formatted labels, never this value. */
 private val PREVIEW_OCCURRED_AT = LocalDateTime(2026, 8, 10, 14, 30)
+
+/** Fixed, matching [PREVIEW_OCCURRED_AT]. A preview that read the clock would drift with the day. */
+private val PREVIEW_MONTH = YearMonth(2026, Month.AUGUST)


### PR DESCRIPTION
Closes finding **#7** of `docs/DATE_AUDIT.md`, the last one open outside the sync wire.

## What was wrong

Reporte was the only screen left resolving a calendar month through `TimeZone.currentSystemDefault()`. The clock could be faked in tests; the zone could not. So no test could put the screen on a month boundary in another zone, and a user near one saw a month the data did not agree with.

The two trend use cases looked injected — they already took a `Clock` — and resolved the end of their window ambiently anyway. Handing them a fake clock proved nothing. That was the actual defect; injecting only the ViewModel would have closed the finding on paper and left the bug.

## What changed

- `ReportViewModel` takes `Clock` + `TimeZone`, and its four `YearMonth.current()` calls take both.
- `GetSavingsRateUseCase` and `GetTopCategoriesOverMonthsUseCase` take the zone beside the clock, and **neither parameter keeps a default**. An ambient default is the defect itself; dropping it turned the two drifting call sites into compile errors instead of silent reads.
- `ReportUiState` loses its wall-clock month default. `HomeUiState` and `SeeTransactionsUiState` lose the same one — the compiler then named all fifteen construction sites, one of which was a preview holding a live `YearMonth.current()`, so what it rendered depended on the day it was opened.
- `ReportScreen` stops answering "is this the current month" from Compose. The ViewModel holds the injected zone, so it owns the question; the answer travels as state.

## The cost of that last move, and how it is paid

Recomposition re-evaluated the old check for free. A flag stored in state has to be re-derived deliberately or it goes stale — a session left open across midnight on the 1st would keep calling last month the current one, suppressing the one-tap way back. It is now derived on every path that writes state, and the KDoc states the limit that survives: every write is not continuously, and an idle screen still waits for the next intent. Reporte has no resume hook and this change does not invent one.

The same clock read also bolds the current month in the Tendencias bar chart, so that marker shares the limit exactly. Both are now named in the tracker and both are covered by rollover tests — a limit disclosed for one of its two symptoms is how this tracker misled a reader once already.

## Tests

Seven new. Each zone test asserts **two** zones off one instant (`2026-09-01T02:00Z` is September at UTC and 31 August at UTC-5), because a single-zone assertion passes by accident on a machine already sitting in that zone.

The two rollover tests step a clock across a month boundary under a running ViewModel. Neither had a natural red — the behaviour was already correct and only the coverage was missing — so the bar-marker one was mutation-checked instead: hoisting the current-month read to construction time reproduced the defect it guards and failed it alone.

## Verification

`./gradlew qualityGate --rerun-tasks` — 205 tasks executed from cold, green, including the iOS compile.

Reviewed adversarially, then through Judgment Day (two blind judges): zero severe findings, zero contradictions. Every info-tier finding from that pass is closed in `f48ae8d`.

## Still open after this

The `#5` follow-up (the sync wire and the Supabase column still carry `date bigint`) and the `#7` sweep — every other `Clock`/`TimeZone` in the codebase still defaults to the ambient one. Both are recorded in `docs/DATE_AUDIT.md` rather than implied to be done.
