### PR TITLE
refactor(di): close the commit-hash debt — typed contract, idiomatic plugin, build-logic on the gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ This is the Opus list (`docs/WORKFLOW.md` model-tier policy) — a Sonnet writer
 
 - **`./gradlew qualityGate` is the gate.** One definition, in `build-logic/.../QualityGateConventionPlugin.kt`;
   the pre-push hook and all three workflows invoke it. detekt over every source set holding code, the host
-  test suites, dev lint, and (macOS only) the iOS compile. Change the plugin, not the callers. **Never
+  test suites, dev lint, (macOS only) the iOS compile, and `:build-logic:test` — named explicitly on the
+  root project, because an included build is unreachable by task-name matching. Change the plugin, not the callers. **Never
   gate on plain `./gradlew detekt`** — it is `NO-SOURCE` on all three KMP modules and only lints `:androidApp`.
 - **Third-party actions in `.github/` are pinned to a commit SHA on purpose** — they hold the signing key,
   the Firebase credentials and the Play service account, and a floating `@v1` can be repointed by whoever

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,11 @@ Tiebreaker: Sonnet writes where the compiler/a test catches the error; Opus writ
 This is the Opus list (`docs/WORKFLOW.md` model-tier policy) — a Sonnet writer does not write here.
 
 - **`./gradlew qualityGate` is the gate.** One definition, in `build-logic/.../QualityGateConventionPlugin.kt`;
-  the pre-push hook and all three workflows invoke it. detekt over every source set holding code, the host
-  test suites, dev lint, (macOS only) the iOS compile, and `:build-logic:test` — named explicitly on the
-  root project, because an included build is unreachable by task-name matching. Change the plugin, not the callers. **Never
+  the pre-push hook and all three workflows invoke it. detekt over every **module** source set holding code,
+  the host test suites, dev lint, and (macOS only) the iOS compile — plus `:build-logic:test`, named
+  explicitly on the root project because an included build is unreachable by task-name matching.
+  `build-logic` is on the gate for its **tests only**: it applies no detekt, so its own sources are the one
+  body of code the gate runs and never lints. Change the plugin, not the callers. **Never
   gate on plain `./gradlew detekt`** — it is `NO-SOURCE` on all three KMP modules and only lints `:androidApp`.
 - **Third-party actions in `.github/` are pinned to a commit SHA on purpose** — they hold the signing key,
   the Firebase credentials and the Play service account, and a floating `@v1` can be repointed by whoever

--- a/androidApp/CLAUDE.md
+++ b/androidApp/CLAUDE.md
@@ -45,7 +45,8 @@ nothing belongs in them anymore.
   `NoDefinitionFoundException` there (verified by mutation).
   The fallback word is a separate matter: `UNKNOWN_COMMIT_HASH` is not referenced anywhere under
   `androidApp/src/main`, only by `BuildInfoTest`, which asserts the shipped hash is that word or a
-  40-hex sha. That gap is in `docs/PROGRESS.md`.
+  40-hex sha. The spelling itself is pinned on both sides — `CommitHashUiTest` for
+  `UNKNOWN_COMMIT_HASH`, `GenerateBuildInfoTaskTest` for `build-logic`'s `UNKNOWN_COMMIT`.
 - `DispatchersProvider`, `CurrentActivityHolder`
 - `SyncLogger` → `CrashReportingSyncLogger` (Crashlytics is Android-only; iOS binds
   `PrintlnSyncLogger` in `KoinIos.kt`)

--- a/androidApp/CLAUDE.md
+++ b/androidApp/CLAUDE.md
@@ -37,15 +37,15 @@ nothing belongs in them anymore.
 - `SupabaseConfig`
 - `GoogleSignInLauncher` (+ `GoogleCredentialClient`)
 - `appVersion` / `googleServerClientId` — named `String`s from `BuildConfig`
-- `commitHash` — named `String` from the **generated** `BuildInfo`, not `BuildConfig`. Its only
-  consumer is `AppNavHost` in `:ui-android`, outside `appModules()`, so `AppGraphKoinTest` cannot
-  see it: `AndroidPlatformModuleTest` asserts the binding here instead — delete the `single` and
-  that test goes red. The qualifier is `:ui-android`'s `COMMIT_HASH_QUALIFIER`, imported by both
-  sites, so the two strings cannot differ. **Nothing checks the consumer still asks for it**: a
-  literal typed over `koinInject(named(...))` in `AppNavHost` compiles green and crashes at launch.
+- `CommitHash` — `:presentation`'s value type over the **generated** `BuildInfo`, not `BuildConfig`.
+  Bound and resolved **by type**, no qualifier: producer and consumer are in different modules, so a
+  named `String` was a contract two sites had to spell alike. Its only consumer is `AppNavHost` in
+  `:ui-android`, outside `appModules()`, so `AppGraphKoinTest` cannot see it —
+  `AndroidPlatformModuleTest` resolves it out of this module instead; deleting the `single` throws
+  `NoDefinitionFoundException` there (verified by mutation).
   The fallback word is a separate matter: `UNKNOWN_COMMIT_HASH` is not referenced anywhere under
   `androidApp/src/main`, only by `BuildInfoTest`, which asserts the shipped hash is that word or a
-  40-hex sha. Both gaps are in `docs/PROGRESS.md`.
+  40-hex sha. That gap is in `docs/PROGRESS.md`.
 - `DispatchersProvider`, `CurrentActivityHolder`
 - `SyncLogger` → `CrashReportingSyncLogger` (Crashlytics is Android-only; iOS binds
   `PrintlnSyncLogger` in `KoinIos.kt`)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
     // The KMP modules get these via justchill.kmp.library; this module applies them directly.
     id("justchill.detekt")
     id("justchill.quality.gate")
-    // Generates BuildInfo.kt (the commit HEAD points at) into the main source set.
+    // Generates BuildInfo.kt (the commit HEAD points at), once per variant, into a directory AGP
+    // owns and adds to that variant's Kotlin sources. There is no `main` source set involved.
     id("justchill.build.info")
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)

--- a/androidApp/src/main/kotlin/com/emm/justchill/core/AndroidPlatformModule.kt
+++ b/androidApp/src/main/kotlin/com/emm/justchill/core/AndroidPlatformModule.kt
@@ -12,7 +12,6 @@ import com.emm.justchill.core.platform.CurrentActivityHolder
 import com.emm.justchill.hh.auth.ActivityGoogleSignInLauncher
 import com.emm.justchill.hh.auth.GoogleCredentialClient
 import com.emm.justchill.hh.auth.GoogleSignInLauncher
-import com.emm.justchill.hh.profile.COMMIT_HASH_QUALIFIER
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
 import org.koin.android.ext.koin.androidContext
@@ -51,13 +50,14 @@ val androidPlatformModule = module {
     // The git commit this APK was built from, FULL 40-char sha. Consumed by AppNavHost, which hands
     // it to the profile footer; the footer shows the first 7 and copies all 40.
     //
+    // Bound by TYPE, not under a qualifier: producer and consumer are in different Gradle modules,
+    // and CommitHash (:presentation) is the declaration both import. See its KDoc.
+    //
     // Deliberately not in testPlatformModule / KoinIos: its only consumer is :ui-android's Compose
     // host, which is Android-only and outside appModules(), so AppGraphKoinTest would be asserting
     // wiring no shared consumer resolves — the same reason DispatchersProvider is absent there.
     // AndroidPlatformModuleTest is what guards this line instead: deleting it turns that test red.
-    // It reads this module's own mappings, so it sees the binding and nothing about the request
-    // AppNavHost makes — a hand-typed literal there still compiles. Tracked in docs/PROGRESS.md.
-    single(named(COMMIT_HASH_QUALIFIER)) { BuildInfo.commitHash }
+    single { CommitHash(BuildInfo.commitHash) }
 
     // Google Sign-In web client id, consumed by AuthViewModel. Empty when supabase.properties is
     // absent; the Google button stays hidden so submitWithGoogle never reaches the launcher.

--- a/androidApp/src/test/kotlin/com/emm/justchill/core/AndroidPlatformModuleTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/core/AndroidPlatformModuleTest.kt
@@ -1,53 +1,48 @@
 package com.emm.justchill.core
 
-import com.emm.justchill.hh.profile.COMMIT_HASH_QUALIFIER
+import com.emm.justchill.BuildInfo
 import org.junit.Test
-import org.koin.core.annotation.KoinInternalApi
-import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 /**
- * Guards the `commitHash` binding in `androidPlatformModule`.
+ * Guards the [CommitHash] binding in `androidPlatformModule`.
  *
  * `AppGraphKoinTest` (`:presentation`) builds `appModules(testPlatformModule)` and cannot see this
  * module at all — `androidPlatformModule` lives here, and `:presentation` does not depend on
  * `:androidApp`. It therefore proves nothing about production wiring, which is why the
  * `commitHash` assertion it used to hold was a fixture checking itself.
  *
- * `named(COMMIT_HASH_QUALIFIER)` is resolved by `AppNavHost` in `:ui-android`, on every launch of
- * every build, before the first screen renders. Deleting the binding compiles clean, passes lint
- * and passes every other suite; it crashes the app at startup. This test is the net.
+ * `CommitHash` is resolved by `AppNavHost` in `:ui-android`, on every launch of every build, before
+ * the first screen renders. Deleting the binding compiles clean, passes lint and passes every other
+ * suite; it crashes the app at startup. This test is the net.
  *
  * It is a net for that one binding, not for the module. `DispatchersProvider` is equally invisible
  * to `AppGraphKoinTest` and equally unasserted here; nothing below covers it.
  *
- * ### Why definitions and not resolution
+ * ### Why only this binding is resolved
  *
- * This module binds the SQLDelight driver, `SharedPreferencesSettings`, the sign-in launcher and
- * `CurrentActivityHolder` — all of which need a real `Context`. Resolving the graph here would need
- * an Android runtime this JVM test does not have. Koin's declared mappings answer the only question
- * that matters ("is it bound, under this qualifier, as a String?") without constructing anything:
- * the `single { }` lambdas are never invoked.
+ * This module also binds the SQLDelight driver, `SharedPreferencesSettings`, the sign-in launcher
+ * and `CurrentActivityHolder` — all of which need a real `Context`. Koin builds `single { }`
+ * definitions lazily, so resolving [CommitHash] alone invokes that one lambda and leaves the
+ * Context-dependent ones untouched; a `koinApplication { }` never starts the global registry
+ * either. Resolving is what makes this test see what `AppNavHost` sees: it asks Koin the same
+ * question, by type, rather than reading this module's own declared mappings back to itself.
  */
-@OptIn(KoinInternalApi::class)
 class AndroidPlatformModuleTest {
 
     @Test
-    fun `androidPlatformModule declares the commit hash the nav host resolves at launch`() {
-        val definition = androidPlatformModule.mappings.values
-            .map { it.beanDefinition }
-            .firstOrNull { it.qualifier == named(COMMIT_HASH_QUALIFIER) }
+    fun `androidPlatformModule binds the commit hash the nav host resolves at launch`() {
+        val koin = koinApplication { modules(androidPlatformModule) }.koin
 
-        assertNotNull(
-            definition,
-            "androidPlatformModule binds nothing under named(\"$COMMIT_HASH_QUALIFIER\"). AppNavHost " +
-                "resolves it before the first screen renders, so the app crashes at launch.",
-        )
-        assertEquals(
-            String::class,
-            definition.primaryType,
-            "named(\"$COMMIT_HASH_QUALIFIER\") is bound, but not as a String — koinInject<String> fails.",
-        )
+        try {
+            assertEquals(
+                CommitHash(BuildInfo.commitHash),
+                koin.get<CommitHash>(),
+                "androidPlatformModule no longer produces the generated commit hash as a CommitHash.",
+            )
+        } finally {
+            koin.close()
+        }
     }
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,6 +19,11 @@ fun marker(plugin: Provider<PluginDependency>): String = plugin.get().run {
 dependencies {
     implementation(marker(libs.plugins.kotlin.multiplatform))
     implementation(marker(libs.plugins.android.kotlin.multiplatform.library))
+    // BuildInfoConventionPlugin configures ApplicationAndroidComponentsExtension, which the
+    // application plugin defines. The type used to arrive transitively through the KMP-library
+    // marker above — same AGP artifact, undeclared — so this build compiled against something it
+    // never asked for. Declared here, the compile classpath states what the code actually uses.
+    implementation(marker(libs.plugins.android.application))
     implementation(marker(libs.plugins.detekt))
 }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -25,6 +25,11 @@ dependencies {
     // never asked for. Declared here, the compile classpath states what the code actually uses.
     implementation(marker(libs.plugins.android.application))
     implementation(marker(libs.plugins.detekt))
+
+    // JUnit4 + kotlin.test, the same pair every other module's suites use. `test` is an associated
+    // compilation of `main`, so the tests reach `internal` declarations without widening them.
+    testImplementation(libs.junit)
+    testImplementation(kotlin("test"))
 }
 
 // Convention plugins are Plugin<Project> classes rather than precompiled .gradle.kts scripts: real

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/BuildInfoConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/BuildInfoConventionPlugin.kt
@@ -30,7 +30,7 @@ import org.gradle.kotlin.dsl.register
  * The KMP modules keep `kotlin.srcDir(taskProvider)` (see [IosSupabaseConfigConventionPlugin]):
  * that is the Kotlin Multiplatform extension, which AGP's source-set rule does not govern.
  *
- * ### Why `withPlugin` and not a plain `extensions.configure`
+ * ### Why `withPlugin`, and why it is followed by an assertion
  *
  * `ApplicationAndroidComponentsExtension` is registered by the application plugin, so configuring it
  * straight out of `apply()` reads whatever is registered at that instant — which made this plugin
@@ -39,6 +39,14 @@ import org.gradle.kotlin.dsl.register
  * androidApp/build.gradle.kts fails configuration with *"Extension of type
  * 'ApplicationAndroidComponentsExtension' does not exist"*. With `withPlugin` the block runs when
  * the application plugin arrives, and both orders generate `BuildInfo.kt` — both were built.
+ *
+ * Deferring costs the failure the eager call gave for free: on a module that is NOT an Android
+ * application the block simply never runs, so nothing is registered, nothing is generated, and the
+ * first thing anyone hears is `Unresolved reference: BuildInfo` from the Kotlin compiler. The
+ * `afterEvaluate` check below puts that failure back where it belongs — configuration of the module
+ * that misapplied the plugin — without taking the ordering fragility back. Same reason
+ * `variant.sources.kotlin` is asserted rather than null-safe-called: a variant with no Kotlin source
+ * container would otherwise register a generator whose output nothing compiles.
  *
  * The AGP application marker is declared in build-logic/build.gradle.kts for the same reason. The
  * type used to arrive transitively through the `android.kotlin.multiplatform.library` marker, so
@@ -57,7 +65,7 @@ import org.gradle.kotlin.dsl.register
 class BuildInfoConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) = with(target) {
-        pluginManager.withPlugin("com.android.application") {
+        pluginManager.withPlugin(APPLICATION_PLUGIN) {
             // Read once, not once per variant: four execs would be four chances to disagree, and
             // the hash is a property of the checkout, not of the variant.
             val hash = gitCommitHash()
@@ -72,11 +80,25 @@ class BuildInfoConventionPlugin : Plugin<Project> {
                         description = "Generates BuildInfo.kt from the git commit HEAD points at."
                         commitHash.set(hash)
                     }
-                    variant.sources.kotlin?.addGeneratedSourceDirectory(
+                    val kotlinSources = checkNotNull(variant.sources.kotlin) {
+                        "Variant '${variant.name}' of $path has no Kotlin source container, so " +
+                            "the generated BuildInfo.kt would never be compiled. The " +
+                            "justchill.build.info plugin needs the Kotlin plugin on this module."
+                    }
+                    kotlinSources.addGeneratedSourceDirectory(
                         generate,
                         GenerateBuildInfoTask::outputDirectory,
                     )
                 }
+            }
+        }
+
+        afterEvaluate {
+            check(pluginManager.hasPlugin(APPLICATION_PLUGIN)) {
+                "The justchill.build.info plugin generates BuildInfo.kt through the Android " +
+                    "APPLICATION variant API, but $path never applied '$APPLICATION_PLUGIN', so " +
+                    "nothing was registered and no BuildInfo.kt exists. Apply it to an Android " +
+                    "application module or remove it from this build file."
             }
         }
     }
@@ -93,4 +115,8 @@ class BuildInfoConventionPlugin : Plugin<Project> {
             commandLine("git", "rev-parse", "HEAD")
         }.standardOutput.asText.get().trim()
     }.getOrDefault(GenerateBuildInfoTask.UNKNOWN_COMMIT)
+
+    private companion object {
+        const val APPLICATION_PLUGIN = "com.android.application"
+    }
 }

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/BuildInfoConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/BuildInfoConventionPlugin.kt
@@ -30,6 +30,20 @@ import org.gradle.kotlin.dsl.register
  * The KMP modules keep `kotlin.srcDir(taskProvider)` (see [IosSupabaseConfigConventionPlugin]):
  * that is the Kotlin Multiplatform extension, which AGP's source-set rule does not govern.
  *
+ * ### Why `withPlugin` and not a plain `extensions.configure`
+ *
+ * `ApplicationAndroidComponentsExtension` is registered by the application plugin, so configuring it
+ * straight out of `apply()` reads whatever is registered at that instant — which made this plugin
+ * depend on the order of the `plugins { }` block. Measured, not assumed: with the eager call, moving
+ * `id("justchill.build.info")` above `alias(libs.plugins.android.application)` in
+ * androidApp/build.gradle.kts fails configuration with *"Extension of type
+ * 'ApplicationAndroidComponentsExtension' does not exist"*. With `withPlugin` the block runs when
+ * the application plugin arrives, and both orders generate `BuildInfo.kt` — both were built.
+ *
+ * The AGP application marker is declared in build-logic/build.gradle.kts for the same reason. The
+ * type used to arrive transitively through the `android.kotlin.multiplatform.library` marker, so
+ * this build compiled against a dependency it never asked for.
+ *
  * ### Why the hash is read here and not in the task
  *
  * `providers.exec { }` resolved at configuration time is a configuration-cache *input*: Gradle
@@ -43,24 +57,26 @@ import org.gradle.kotlin.dsl.register
 class BuildInfoConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) = with(target) {
-        // Read once, not once per variant: four execs would be four chances to disagree, and the
-        // hash is a property of the checkout, not of the variant.
-        val hash = gitCommitHash()
+        pluginManager.withPlugin("com.android.application") {
+            // Read once, not once per variant: four execs would be four chances to disagree, and
+            // the hash is a property of the checkout, not of the variant.
+            val hash = gitCommitHash()
 
-        extensions.configure<ApplicationAndroidComponentsExtension> {
-            onVariants { variant ->
-                // One task per variant because addGeneratedSourceDirectory assigns the output
-                // directory itself; a single shared task would have four variants fighting over it.
-                val generate = tasks.register<GenerateBuildInfoTask>(
-                    "generate${variant.name.replaceFirstChar(Char::uppercase)}BuildInfo",
-                ) {
-                    description = "Generates BuildInfo.kt from the git commit HEAD points at."
-                    commitHash.set(hash)
+            extensions.configure<ApplicationAndroidComponentsExtension> {
+                onVariants { variant ->
+                    // One task per variant because addGeneratedSourceDirectory assigns the output
+                    // directory itself; one shared task would have four variants fighting over it.
+                    val generate = tasks.register<GenerateBuildInfoTask>(
+                        "generate${variant.name.replaceFirstChar(Char::uppercase)}BuildInfo",
+                    ) {
+                        description = "Generates BuildInfo.kt from the git commit HEAD points at."
+                        commitHash.set(hash)
+                    }
+                    variant.sources.kotlin?.addGeneratedSourceDirectory(
+                        generate,
+                        GenerateBuildInfoTask::outputDirectory,
+                    )
                 }
-                variant.sources.kotlin?.addGeneratedSourceDirectory(
-                    generate,
-                    GenerateBuildInfoTask::outputDirectory,
-                )
             }
         }
     }

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/GenerateBuildInfoTask.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/GenerateBuildInfoTask.kt
@@ -16,9 +16,12 @@ import org.gradle.work.DisableCachingByDefault
  * nearest release tag and stays identical across dozens of builds. The commit hash is the only
  * identifier that moves with the code.
  *
- * The hash arrives as a plain `@Input` string rather than being read here, so the configuration
- * cache can decide whether this task is up to date without running git during execution, and so
- * the task itself has no dependency on a git checkout being present.
+ * The hash arrives as a plain `@Input` string rather than being read here, so the task itself has
+ * no dependency on a git checkout being present and its up-to-date check is a comparison of that
+ * declared input — reading git inside the action instead would make the change invisible to it.
+ * Configuration caching is a second, separate mechanism: [BuildInfoConventionPlugin] reads git at
+ * configuration time, which registers the command as a configuration-cache input and is what
+ * invalidates the cached entry when HEAD moves.
  *
  * ### Known limitation: a dirty working tree
  *
@@ -88,10 +91,11 @@ abstract class GenerateBuildInfoTask : DefaultTask() {
          * the same literal on the consuming side — build-logic is not on the app's compile
          * classpath, so they cannot be one constant.
          *
-         * Nothing links them, and `GenerateBuildInfoTaskTest` cannot: it reads this constant, so it
-         * agrees with whatever this says. Editing this word therefore leaves every suite green
-         * while a git-less build renders "Commit unknow" with a copy button. If you change it,
-         * change `UNKNOWN_COMMIT_HASH` by hand.
+         * Nothing in the build links the two, so each side is pinned by a test that spells the
+         * word out instead of reading the constant: `GenerateBuildInfoTaskTest.the sentinel is the
+         * exact word the app side spells out` here, `CommitHashUiTest` there. Retyping this value
+         * turns the first red; retyping `UNKNOWN_COMMIT_HASH` turns the second red. Changing the
+         * word for real means editing four places: both constants and both tests.
          */
         const val UNKNOWN_COMMIT = "unknown"
 

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/GenerateBuildInfoTask.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/GenerateBuildInfoTask.kt
@@ -88,9 +88,10 @@ abstract class GenerateBuildInfoTask : DefaultTask() {
          * the same literal on the consuming side — build-logic is not on the app's compile
          * classpath, so they cannot be one constant.
          *
-         * Nothing links them. build-logic has no test source set, so editing this word compiles,
-         * ships, and leaves every suite green while a git-less build renders "Commit unknow" with
-         * a copy button. If you change it, change `UNKNOWN_COMMIT_HASH` by hand.
+         * Nothing links them, and `GenerateBuildInfoTaskTest` cannot: it reads this constant, so it
+         * agrees with whatever this says. Editing this word therefore leaves every suite green
+         * while a git-less build renders "Commit unknow" with a copy button. If you change it,
+         * change `UNKNOWN_COMMIT_HASH` by hand.
          */
         const val UNKNOWN_COMMIT = "unknown"
 
@@ -103,6 +104,9 @@ abstract class GenerateBuildInfoTask : DefaultTask() {
          * a Kotlin string literal, and a quote, a backslash or the trailing newline `git` always
          * prints would break the build in a file no human ever opens. Rejecting outright beats
          * escaping — a hash is either 40 hex characters or it is not a hash.
+         *
+         * `GenerateBuildInfoTaskTest` covers both branches, including the `-dirty` suffix the KDoc
+         * above says must stay rejected; it runs on `./gradlew qualityGate` as `:build-logic:test`.
          */
         fun normalizeCommitHash(raw: String): String {
             val trimmed = raw.trim().lowercase()

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
@@ -25,9 +25,10 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
  * the root branch in [apply].
  *
  * This plugin is repo-specific, not a general-purpose one: that root branch names the included
- * build `build-logic` literally, so applying it to the root of a build that does not include one
- * fails configuration. That is the intended outcome — a silently absent build-logic suite is the
- * exact drift this class exists to stop.
+ * build `build-logic` literally. On a root project whose build includes no such build, Gradle's
+ * `gradle.includedBuild("build-logic")` throws `UnknownDomainObjectException` while the gate task
+ * is being configured. Failing there is preferable to skipping the suite silently, which is the
+ * drift this class exists to stop.
  */
 class QualityGateConventionPlugin : Plugin<Project> {
 

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
@@ -20,6 +20,14 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
  *  - the schema checks in [SCHEMA_GATE_TASKS], for the module that has a SQLDelight schema
  *  - its host test suite, contributed by [KmpLibraryConventionPlugin] or the module's build file
  *  - the iOS compile, on macOS hosts only, contributed by [KmpLibraryConventionPlugin]
+ *
+ * And once, on the root project only: `:build-logic:test`, the suite of the included build. See
+ * the root branch in [apply].
+ *
+ * This plugin is repo-specific, not a general-purpose one: that root branch names the included
+ * build `build-logic` literally, so applying it to the root of a build that does not include one
+ * fails configuration. That is the intended outcome — a silently absent build-logic suite is the
+ * exact drift this class exists to stop.
  */
 class QualityGateConventionPlugin : Plugin<Project> {
 
@@ -27,8 +35,9 @@ class QualityGateConventionPlugin : Plugin<Project> {
         target.tasks.register(GATE_TASK) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description =
-                "Runs every check that must pass before pushing: detekt, host tests, and " +
-                    "(on macOS) the iOS compile. Invoked by the pre-push hook and by CI."
+                "Runs every check that must pass before pushing: detekt, host tests, " +
+                    ":build-logic:test, and (on macOS) the iOS compile. Invoked by the pre-push " +
+                    "hook and by CI."
 
             // Lazy and existence-safe: a module only contributes the tasks it actually has, and
             // tasks registered after this plugin still land on the gate.
@@ -44,7 +53,11 @@ class QualityGateConventionPlugin : Plugin<Project> {
             // task-name matching only walks this build's projects. Its own suite has to be named,
             // and only once — hung off the root project, which applies this plugin for no other
             // reason. Everything else on the gate is a module contributing its own tasks.
-            if (target == target.rootProject) {
+            //
+            // `parent == null` rather than `== rootProject`: reaching for `rootProject` is
+            // cross-project access, which is what blocks Gradle's Project Isolation — the same
+            // thing the root build file stays thin for.
+            if (target.parent == null) {
                 dependsOn(target.gradle.includedBuild(BUILD_LOGIC_BUILD).task(":$TEST_TASK"))
             }
         }

--- a/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/emm/buildlogic/QualityGateConventionPlugin.kt
@@ -39,11 +39,23 @@ class QualityGateConventionPlugin : Plugin<Project> {
                         it.name in SCHEMA_GATE_TASKS
                 },
             )
+
+            // build-logic is an INCLUDED build, so `./gradlew qualityGate` never reaches its tasks:
+            // task-name matching only walks this build's projects. Its own suite has to be named,
+            // and only once — hung off the root project, which applies this plugin for no other
+            // reason. Everything else on the gate is a module contributing its own tasks.
+            if (target == target.rootProject) {
+                dependsOn(target.gradle.includedBuild(BUILD_LOGIC_BUILD).task(":$TEST_TASK"))
+            }
         }
     }
 
     companion object {
         const val GATE_TASK = "qualityGate"
+
+        /** The build wired in by `pluginManagement { includeBuild(...) }` — this very build. */
+        private const val BUILD_LOGIC_BUILD = "build-logic"
+        private const val TEST_TASK = "test"
 
         /**
          * The detekt tasks that constitute real coverage.

--- a/build-logic/src/test/kotlin/com/emm/buildlogic/GenerateBuildInfoTaskTest.kt
+++ b/build-logic/src/test/kotlin/com/emm/buildlogic/GenerateBuildInfoTaskTest.kt
@@ -6,7 +6,8 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 /**
- * The first tests build-logic has ever had, and they exist for one function.
+ * The first tests build-logic has ever had. Almost all of them exist for one function; the
+ * remaining one pins the spelling of [UNKNOWN_COMMIT], whose twin lives in another Gradle build.
  *
  * [normalizeCommitHash] is the only thing standing between `git rev-parse HEAD` and a Kotlin string
  * literal written into a generated file. Every other suite in the repo runs against code that is
@@ -18,6 +19,16 @@ import kotlin.test.assertEquals
  * depends on `:build-logic:test` explicitly (see [QualityGateConventionPlugin]).
  */
 class GenerateBuildInfoTaskTest {
+
+    @Test
+    fun `the sentinel is the exact word the app side spells out`() {
+        // build-logic is not on the app's compile classpath, so UNKNOWN_COMMIT and :ui-android's
+        // UNKNOWN_COMMIT_HASH cannot be one constant. This spells the word out rather than reading
+        // it, which is what makes retyping the constant fail here instead of at runtime, in a
+        // git-less build rendering a footer nobody is watching. CommitHashUiTest does the same on
+        // the consuming side, via its GENERATOR_SENTINEL.
+        assertEquals("unknown", UNKNOWN_COMMIT)
+    }
 
     @Test
     fun `a full lowercase sha passes through unchanged`() {

--- a/build-logic/src/test/kotlin/com/emm/buildlogic/GenerateBuildInfoTaskTest.kt
+++ b/build-logic/src/test/kotlin/com/emm/buildlogic/GenerateBuildInfoTaskTest.kt
@@ -1,0 +1,85 @@
+package com.emm.buildlogic
+
+import com.emm.buildlogic.GenerateBuildInfoTask.Companion.UNKNOWN_COMMIT
+import com.emm.buildlogic.GenerateBuildInfoTask.Companion.normalizeCommitHash
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * The first tests build-logic has ever had, and they exist for one function.
+ *
+ * [normalizeCommitHash] is the only thing standing between `git rev-parse HEAD` and a Kotlin string
+ * literal written into a generated file. Every other suite in the repo runs against code that is
+ * already compiled, so the rejection branch here was unreachable from all of them: a value carrying
+ * a quote or a newline would have produced a `BuildInfo.kt` that does not parse, in a file no human
+ * opens, and nothing would have said which change caused it.
+ *
+ * These run on `./gradlew qualityGate` — build-logic is an included build, so the root project
+ * depends on `:build-logic:test` explicitly (see [QualityGateConventionPlugin]).
+ */
+class GenerateBuildInfoTaskTest {
+
+    @Test
+    fun `a full lowercase sha passes through unchanged`() {
+        assertEquals(FULL_SHA, normalizeCommitHash(FULL_SHA))
+    }
+
+    @Test
+    fun `an uppercase sha is lowercased rather than rejected`() {
+        assertEquals(FULL_SHA, normalizeCommitHash(FULL_SHA.uppercase()))
+    }
+
+    @Test
+    fun `the trailing newline git always prints is stripped`() {
+        assertEquals(FULL_SHA, normalizeCommitHash("$FULL_SHA\n"))
+    }
+
+    @Test
+    fun `surrounding whitespace is stripped`() {
+        assertEquals(FULL_SHA, normalizeCommitHash("  $FULL_SHA\t\r\n"))
+    }
+
+    @Test
+    fun `an empty value is the sentinel`() {
+        assertEquals(UNKNOWN_COMMIT, normalizeCommitHash(""))
+        assertEquals(UNKNOWN_COMMIT, normalizeCommitHash("   "))
+    }
+
+    @Test
+    fun `a describe --dirty suffix is rejected, not truncated`() {
+        // Documented in GenerateBuildInfoTask: widening the regex to admit this suffix is the one
+        // change that would make the generated file unsafe again.
+        assertEquals(UNKNOWN_COMMIT, normalizeCommitHash("$FULL_SHA-dirty"))
+    }
+
+    @Test
+    fun `a short sha is not a sha`() {
+        assertEquals(UNKNOWN_COMMIT, normalizeCommitHash(FULL_SHA.take(7)))
+    }
+
+    @Test
+    fun `characters that would break the generated string literal are rejected`() {
+        // Each of these, interpolated into `val commitHash: String = "$full"`, either closes the
+        // literal early, starts an escape sequence, or opens a template expression.
+        val hostile = listOf(
+            """${FULL_SHA.take(38)}"; val pwned: String = """",
+            """${FULL_SHA.take(38)}\n""",
+            "${FULL_SHA.take(30)}\$hostile",
+            "${FULL_SHA.take(30)}\${System.exit(0)}",
+            "$FULL_SHA\nval extra: String = \"\"",
+        )
+
+        for (raw in hostile) {
+            assertEquals(
+                UNKNOWN_COMMIT,
+                normalizeCommitHash(raw),
+                "normalizeCommitHash accepted <$raw>, which does not survive being written into a " +
+                    "Kotlin string literal.",
+            )
+        }
+    }
+
+    private companion object {
+        const val FULL_SHA = "4e47828d1f2a3b4c5d6e7f8091a2b3c4d5e6f708"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,10 @@
 // itself. Cross-project configuration is what blocks Gradle's Project Isolation, and it also made
 // this file the place where "how is detekt set up?" secretly lived.
 plugins {
+    // The one thing the root project is for: `build-logic` is an included build, so nothing in the
+    // module graph can reach its `test` task. The gate task registered here names it. See
+    // QualityGateConventionPlugin.
+    id("justchill.quality.gate")
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.google.crashlytics) apply false

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -256,12 +256,17 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 - [ ] `:ui-android:detektAndroidMainSourceSet` reporta **21** issues. Preexistente y deliberadamente
   fuera del gate: `detektMainAndroid` cubre los mismos archivos **con** type resolution, así que
   sumarlo serían más tareas y no más cobertura — el razonamiento está en `QualityGateConventionPlugin`.
-- [ ] `GenerateBuildInfoTask.UNKNOWN_COMMIT` es la tercera copia de la palabra `"unknown"` y
-  cambiarla ahí sigue sin poner en rojo nada. `CommitHashUiTest` fija el lado de `:ui-android`
-  escribiendo la palabra a mano; el lado del generador no lo puede fijar nadie, porque `build-logic`
-  no está en el compile classpath de la app y `GenerateBuildInfoTaskTest` **lee** la constante en vez
-  de deletrearla, así que se mueve con ella. Un test de build-logic no puede cerrar esta mitad.
-  La otra mitad **sí se cerró**: `build-logic` ya tiene source set de tests y cuelga de
+- [x] `GenerateBuildInfoTask.UNKNOWN_COMMIT` es la tercera copia de la palabra `"unknown"`, y ahora
+  **cada copia tiene su propio test que la deletrea**: `CommitHashUiTest` (`GENERATOR_SENTINEL`) fija
+  el lado de `:ui-android`, y `GenerateBuildInfoTaskTest.the sentinel is the exact word the app side
+  spells out` fija el del generador con un `assertEquals("unknown", UNKNOWN_COMMIT)`. La entrada
+  anterior decía que un test de build-logic "no puede cerrar esta mitad" porque `GenerateBuildInfoTaskTest`
+  **lee** la constante en vez de deletrearla — eso describía los tests que había, no un límite: un
+  test puede deletrear la palabra igual que lo hace el otro módulo. Sigue sin haber nada que **linkee**
+  las dos constantes (`build-logic` no está en el compile classpath de la app), así que cambiar la
+  palabra de verdad son cuatro ediciones: las dos constantes y los dos tests. Verificado por
+  mutación: escribir `"unknwon"` en `UNKNOWN_COMMIT` pone `:build-logic:test` en `FAILED`.
+  La otra mitad **también está cerrada**: `build-logic` ya tiene source set de tests y cuelga de
   `qualityGate`. `normalizeCommitHash` tiene ocho tests —sha válido, mayúsculas, newline final,
   whitespace alrededor, comillas/backslash/`$`/newline, sufijo `-dirty`, sha corto, vacío— y el gate
   los corre como `:build-logic:test` (`build.gradle.kts` raíz aplica `justchill.quality.gate` solo
@@ -281,14 +286,16 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 
 ### Docs y comentarios que afirman cosas falsas
 
-- [ ] `ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt:50-66` — diecisiete
+- [ ] `ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt:51-67` — diecisiete
   líneas de cabecera que describen un host que ya no existe. Las tres afirmaciones son falsas:
   no es un "single Compose Multiplatform nav host for both Android and iOS" (`:ui-android` solo
   tiene `androidMain` y `androidHostTest`); no corre sobre el port navigation3-UI de JetBrains
   (`ui-android/build.gradle.kts:50-52` dice que el port "lost its reason to exist" y que runtime y
   UI son de Google); y `PlatformHostActions + startTab` no están detrás de `expect/actual` — son
   una `interface` y un `val` planos en `hh/shared/PlatformHostActions.kt:39` y `:168`. Es código,
-  no doc: queda anotado acá y el archivo no se tocó.
+  no doc: queda anotado acá y **la cabecera sigue sin tocarse**. El archivo sí se tocó por otro
+  motivo (el import de `CommitHash` y el comentario del footer de commit, `:29` y `:78-85`), lo que
+  desplazó la cabecera de `:50-66` a `:51-67` — este pin se re-verifica en cada edición del archivo.
 - [ ] `docs/DESIGN_SYSTEM.md` §5 documenta 5 radios con otro esquema de nombres (`radius.0`,
   `radius.s` 6dp, `radius.m`, `radius.l`, `radius.full`); `EmmRadii.kt` ships **9** (`r0`, `rXS` 8dp,
   `rS` 10dp, `rM`, `rL`, `rXL`, `rXXL`, `rLTop`, `rFull`) y `rXS` —el que usa el footer de commit— no
@@ -409,10 +416,10 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   así que la fuga es de otro test de la misma JVM, no de este.
 - [x] Deps huérfanas en `libs.versions.toml`: **no quedan**. La entrada anterior decía "entre ellas
   `firebase-analytics`, declarada pero sin usar" y eso hoy es falso — el catálogo solo declara
-  `firebase-bom` y `firebase-crashlytics`, y las dos se usan en `androidApp/build.gradle.kts:214-215`.
+  `firebase-bom` y `firebase-crashlytics`, y las dos se usan en `androidApp/build.gradle.kts:217-218`.
   Los únicos alias que no aparecen en ningún `.gradle.kts` son `detekt-ktlint-wrapper` y
   `detekt-compose-rules`, y entran por `libs.library(...)` desde
-  `build-logic/.../DetektConventionPlugin.kt:41-42`.
+  `build-logic/.../DetektConventionPlugin.kt:42-43`.
 
 ### Infraestructura
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -347,11 +347,14 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   se auto-cura — solo latencia.
 - [ ] Pasada de performance de Compose: `derivedStateOf`, lambdas recordadas, `contentType` en
   `LazyColumn`.
-- [ ] `BuildInfoConventionPlugin` no declara marker para `libs.plugins.android.application` (el tipo
-  de variante de AGP entra solo transitivamente) y llama a
-  `extensions.configure<ApplicationAndroidComponentsExtension>` de forma eager al aplicarse, en vez de
-  diferir con `pluginManager.withPlugin("com.android.application")`. Depende del orden del bloque
-  `plugins { }` en `androidApp/build.gradle.kts`.
+- [x] **`BuildInfoConventionPlugin` ya no depende del orden del bloque `plugins { }`.**
+  `build-logic/build.gradle.kts` declara el marker de `libs.plugins.android.application` (el tipo de
+  variante de AGP entraba solo transitivamente por el marker de KMP-library) y el plugin difiere con
+  `pluginManager.withPlugin("com.android.application")`. La fragilidad era real y está medida: con el
+  `extensions.configure` eager, subir `id("justchill.build.info")` arriba de
+  `alias(libs.plugins.android.application)` falla con *"Extension of type
+  'ApplicationAndroidComponentsExtension' does not exist"*; con `withPlugin`, los dos órdenes generan
+  `BuildInfo.kt` — los dos se construyeron.
 - [ ] La escritura al portapapeles del commit, el split short-en-pantalla/40-al-copiar y la rama
   `SDK_INT < TIRAMISU` del snackbar (`ProfileEntries.kt`) no tienen cobertura automática en ninguna
   tarea del gate. `commitHashUi()` sí la tiene; lo que la rodea, no.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -256,12 +256,18 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 - [ ] `:ui-android:detektAndroidMainSourceSet` reporta **21** issues. Preexistente y deliberadamente
   fuera del gate: `detektMainAndroid` cubre los mismos archivos **con** type resolution, así que
   sumarlo serían más tareas y no más cobertura — el razonamiento está en `QualityGateConventionPlugin`.
-- [ ] `build-logic` no tiene source set de tests y no cuelga de `qualityGate`, así que
-  `normalizeCommitHash` (`GenerateBuildInfoTask.kt:99`) —la única barrera contra inyectar texto en el
-  literal Kotlin que se genera— no tiene un solo test y su rama de rechazo no se ejecuta nunca.
-  Lo mismo cubre a `GenerateBuildInfoTask.UNKNOWN_COMMIT`: es la tercera copia de la palabra
-  `"unknown"` y cambiarla ahí no pone en rojo nada — `CommitHashUiTest` fija el lado de `:ui-android`
-  escribiendo la palabra a mano, pero el lado del generador no lo mira nadie.
+- [ ] `GenerateBuildInfoTask.UNKNOWN_COMMIT` es la tercera copia de la palabra `"unknown"` y
+  cambiarla ahí sigue sin poner en rojo nada. `CommitHashUiTest` fija el lado de `:ui-android`
+  escribiendo la palabra a mano; el lado del generador no lo puede fijar nadie, porque `build-logic`
+  no está en el compile classpath de la app y `GenerateBuildInfoTaskTest` **lee** la constante en vez
+  de deletrearla, así que se mueve con ella. Un test de build-logic no puede cerrar esta mitad.
+  La otra mitad **sí se cerró**: `build-logic` ya tiene source set de tests y cuelga de
+  `qualityGate`. `normalizeCommitHash` tiene ocho tests —sha válido, mayúsculas, newline final,
+  comillas/backslash/`$`/newline, sufijo `-dirty`, sha corto, vacío— y el gate los corre como
+  `:build-logic:test` (`build.gradle.kts` raíz aplica `justchill.quality.gate` solo para eso;
+  `build-logic` es un included build y el matcheo por nombre de tarea no lo alcanza). Verificado por
+  mutación: ensanchar el regex a `[0-9a-f]{40}(-dirty)?` pone `./gradlew qualityGate` en
+  `BUILD FAILED` con `Execution failed for task ':build-logic:test'`.
 
 ### Docs y comentarios que afirman cosas falsas
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -355,18 +355,24 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 - [ ] La escritura al portapapeles del commit, el split short-en-pantalla/40-al-copiar y la rama
   `SDK_INT < TIRAMISU` del snackbar (`ProfileEntries.kt`) no tienen cobertura automática en ninguna
   tarea del gate. `commitHashUi()` sí la tiene; lo que la rodea, no.
-- [ ] Lo que `AppNavHost` **pide** no lo observa ningún test. `AndroidPlatformModuleTest` lee los
-  `mappings` del propio `androidPlatformModule`, así que ve el binding y nada de la petición del
-  consumidor: reemplazar `koinInject(named(COMMIT_HASH_QUALIFIER))` por un
-  literal escrito a mano compila, pasa el gate entero y revienta la app al arrancar (`AppNavHost.kt:82`).
-  Cerrarlo pide un
-  test de runtime de Compose que `:ui-android` hoy no tiene (no hay `androidTest` en el módulo, y el
-  host test es JVM puro).
-- [ ] `COMMIT_HASH_QUALIFIER` vive en un paquete de feature de UI (`hh/profile/CommitHashUi.kt`)
-  cuando `:presentation` —donde vive el DI del proyecto— es igual de visible para `:androidApp` y
-  para `:ui-android` (`ui-android/build.gradle.kts:38` declara `api(project(":presentation"))`, y
-  `AndroidPlatformModule.kt` ya consume `DispatchersProvider` y `SupabaseConfig` de ahí). El archivo
-  queda con dos razones para cambiar: el contrato de DI y el estado de presentación del footer.
+- [x] **El contrato productor/consumidor del commit hash ya no es un string.** `COMMIT_HASH_QUALIFIER`
+  se borró; `androidPlatformModule` bindea `CommitHash` (value class sobre `String`) y `AppNavHost`
+  lo pide por tipo (`koinInject<CommitHash>().value`). No queda ningún literal que escribir mal:
+  cualquier desacuerdo entre los dos sitios es un `unresolved reference` del compilador, no un crash
+  al arrancar. `AndroidPlatformModuleTest` pasó de leer los `mappings` del propio módulo a **resolver**
+  el tipo contra un `koinApplication { }`, o sea le hace a Koin la misma pregunta que `AppNavHost`;
+  borrar el `single` lo pone en rojo con `NoDefinitionFoundException` (verificado por mutación).
+  Lo que **no** cambió: sigue sin haber test que observe la línea 82 de `AppNavHost` en sí. Eso solo
+  importaría si alguien reescribiera esa línea para pedir *otro* tipo existente, que es un rewrite,
+  no un typo.
+- [x] **El contrato de DI salió del paquete de feature de UI.** Vive en
+  `presentation/src/commonMain/.../core/CommitHash.kt`, al lado de `SupabaseConfig` —
+  `:presentation` es visible para `:androidApp` y para `:ui-android`
+  (`ui-android/build.gradle.kts:38` declara `api(project(":presentation"))`). commonMain se exporta a
+  iOS como `JustChillKit` y un holder sobre `String` no arrastra Compose, `java.*` ni `android.*`:
+  `compileKotlinIosSimulatorArm64` y `linkDebugFrameworkIosSimulatorArm64` (SKIE) verdes.
+  `hh/profile/CommitHashUi.kt` queda con una sola razón para cambiar: el estado de presentación del
+  footer.
 - [ ] `CommitHashUi.Available.fullHash` no lo lee ningún código de producción: `ProfileScreen`
   consume solo `label`, y el camino del portapapeles copia el string inyectado crudo, no el valor
   clasificado. Hoy solo lo miran el `equals` de la data class y `CommitHashUiTest`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -263,11 +263,21 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   de deletrearla, así que se mueve con ella. Un test de build-logic no puede cerrar esta mitad.
   La otra mitad **sí se cerró**: `build-logic` ya tiene source set de tests y cuelga de
   `qualityGate`. `normalizeCommitHash` tiene ocho tests —sha válido, mayúsculas, newline final,
-  comillas/backslash/`$`/newline, sufijo `-dirty`, sha corto, vacío— y el gate los corre como
-  `:build-logic:test` (`build.gradle.kts` raíz aplica `justchill.quality.gate` solo para eso;
-  `build-logic` es un included build y el matcheo por nombre de tarea no lo alcanza). Verificado por
-  mutación: ensanchar el regex a `[0-9a-f]{40}(-dirty)?` pone `./gradlew qualityGate` en
-  `BUILD FAILED` con `Execution failed for task ':build-logic:test'`.
+  whitespace alrededor, comillas/backslash/`$`/newline, sufijo `-dirty`, sha corto, vacío— y el gate
+  los corre como `:build-logic:test` (`build.gradle.kts` raíz aplica `justchill.quality.gate` solo
+  para eso; `build-logic` es un included build y el matcheo por nombre de tarea no lo alcanza).
+  Verificado por mutación: ensanchar el regex a `[0-9a-f]{40}(-dirty)?` pone `./gradlew qualityGate`
+  en `BUILD FAILED` con `Execution failed for task ':build-logic:test'`.
+- [ ] El **template** de `GenerateBuildInfoTask.generate()` no tiene test: `normalizeCommitHash` ya
+  está cubierto, pero borrar las comillas de `"$full"` en el `trimMargin()` no pone en rojo nada
+  dentro de `build-logic`. Lo agarraría `:androidApp:compileDevDebugKotlin`, que no es lo mismo que
+  un test y no dice qué cambió. Cerrarlo pide invocar la tarea de verdad (`ProjectBuilder` o
+  `GradleRunner`) contra un directorio temporal y leer el archivo generado — más maquinaria de la
+  que correspondía meter en la limpieza que agregó el source set. Omisión elegida, no accidental.
+- [ ] `build-logic` **corre en el gate pero no se lintea**: no aplica detekt (su build file aplica
+  solo `kotlin-dsl`; la entrada de detekt ahí es un marker `implementation` para poder *escribir*
+  `DetektConventionPlugin`). `GenerateBuildInfoTaskTest.kt` es el único archivo que el gate ejecuta
+  y nunca analiza.
 
 ### Docs y comentarios que afirman cosas falsas
 
@@ -366,20 +376,25 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   tarea del gate. `commitHashUi()` sí la tiene; lo que la rodea, no.
 - [x] **El contrato productor/consumidor del commit hash ya no es un string.** `COMMIT_HASH_QUALIFIER`
   se borró; `androidPlatformModule` bindea `CommitHash` (value class sobre `String`) y `AppNavHost`
-  lo pide por tipo (`koinInject<CommitHash>().value`). No queda ningún literal que escribir mal:
-  cualquier desacuerdo entre los dos sitios es un `unresolved reference` del compilador, no un crash
-  al arrancar. `AndroidPlatformModuleTest` pasó de leer los `mappings` del propio módulo a **resolver**
-  el tipo contra un `koinApplication { }`, o sea le hace a Koin la misma pregunta que `AppNavHost`;
-  borrar el `single` lo pone en rojo con `NoDefinitionFoundException` (verificado por mutación).
-  Lo que **no** cambió: sigue sin haber test que observe la línea 82 de `AppNavHost` en sí. Eso solo
-  importaría si alguien reescribiera esa línea para pedir *otro* tipo existente, que es un rewrite,
-  no un typo.
+  lo pide por tipo (`koinInject<CommitHash>().value`). Lo que compra es exactamente una cosa: **no
+  queda ningún string que escribir mal**. No hace que los dos lados no puedan discrepar —
+  `koinInject<String>()` escrito en esa línea compila verde y revienta al arrancar, igual que antes.
+  El mecanismo frena un typo, no un rewrite. `AndroidPlatformModuleTest` pasó de leer los `mappings`
+  del propio módulo a **resolver** el tipo contra un `koinApplication { }`, o sea le hace a Koin la
+  misma pregunta que `AppNavHost`; borrar el `single` lo pone en rojo con `NoDefinitionFoundException`
+  (verificado por mutación). Lo que **no** cambió: sigue sin haber test que observe la línea de
+  `AppNavHost` en sí.
 - [x] **El contrato de DI salió del paquete de feature de UI.** Vive en
   `presentation/src/commonMain/.../core/CommitHash.kt`, al lado de `SupabaseConfig` —
   `:presentation` es visible para `:androidApp` y para `:ui-android`
-  (`ui-android/build.gradle.kts:38` declara `api(project(":presentation"))`). commonMain se exporta a
-  iOS como `JustChillKit` y un holder sobre `String` no arrastra Compose, `java.*` ni `android.*`:
+  (`ui-android/build.gradle.kts:38` declara `api(project(":presentation"))`). commonMain es
+  compose-free y un holder sobre `String` no arrastra Compose, `java.*` ni `android.*`:
   `compileKotlinIosSimulatorArm64` y `linkDebugFrameworkIosSimulatorArm64` (SKIE) verdes.
+  Al `JustChillKit.h` generado **no llega**: Kotlin/Native no exporta `@JvmInline value class` a
+  Obj-C y ninguna declaración exportada lo referencia (cero ocurrencias de `CommitHash` en el
+  header, contra `JCKSupabaseConfig` que sí está). Es a propósito — ninguna pantalla Swift muestra
+  el commit, así que un `data class` solo agregaría un símbolo que nadie del otro lado llama. El
+  KDoc del tipo dice qué hacer el día que iOS lo necesite.
   `hh/profile/CommitHashUi.kt` queda con una sola razón para cambiar: el estado de presentación del
   footer.
 - [ ] `CommitHashUi.Available.fullHash` no lo lee ningún código de producción: `ProfileScreen`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -294,7 +294,7 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   UI son de Google); y `PlatformHostActions + startTab` no están detrás de `expect/actual` — son
   una `interface` y un `val` planos en `hh/shared/PlatformHostActions.kt:39` y `:168`. Es código,
   no doc: queda anotado acá y **la cabecera sigue sin tocarse**. El archivo sí se tocó por otro
-  motivo (el import de `CommitHash` y el comentario del footer de commit, `:29` y `:78-85`), lo que
+  motivo (el import de `CommitHash` y el comentario del footer de commit, `:29` y `:78-87`), lo que
   desplazó la cabecera de `:50-66` a `:51-67` — este pin se re-verifica en cada edición del archivo.
 - [ ] `docs/DESIGN_SYSTEM.md` §5 documenta 5 radios con otro esquema de nombres (`radius.0`,
   `radius.s` 6dp, `radius.m`, `radius.l`, `radius.full`); `EmmRadii.kt` ships **9** (`r0`, `rXS` 8dp,
@@ -392,16 +392,11 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   (verificado por mutación). Lo que **no** cambió: sigue sin haber test que observe la línea de
   `AppNavHost` en sí.
 - [x] **El contrato de DI salió del paquete de feature de UI.** Vive en
-  `presentation/src/commonMain/.../core/CommitHash.kt`, al lado de `SupabaseConfig` —
-  `:presentation` es visible para `:androidApp` y para `:ui-android`
-  (`ui-android/build.gradle.kts:38` declara `api(project(":presentation"))`). commonMain es
-  compose-free y un holder sobre `String` no arrastra Compose, `java.*` ni `android.*`:
-  `compileKotlinIosSimulatorArm64` y `linkDebugFrameworkIosSimulatorArm64` (SKIE) verdes.
-  Al `JustChillKit.h` generado **no llega**: Kotlin/Native no exporta `@JvmInline value class` a
-  Obj-C y ninguna declaración exportada lo referencia (cero ocurrencias de `CommitHash` en el
-  header, contra `JCKSupabaseConfig` que sí está). Es a propósito — ninguna pantalla Swift muestra
-  el commit, así que un `data class` solo agregaría un símbolo que nadie del otro lado llama. El
-  KDoc del tipo dice qué hacer el día que iOS lo necesite.
+  `presentation/src/androidMain/.../core/CommitHash.kt`, al lado de donde vive el DI del proyecto.
+  `:ui-android` lo ve por `api(project(":presentation"))` (`ui-android/build.gradle.kts:38`) y
+  `:androidApp` a través de `:ui-android`. Está en `androidMain` y no en commonMain porque productor
+  y consumidor son los dos Android-only: así el tipo no entra a la compilación de Kotlin/Native y la
+  pregunta por la superficie exportada a iOS no existe.
   `hh/profile/CommitHashUi.kt` queda con una sola razón para cambiar: el estado de presentación del
   footer.
 - [ ] `CommitHashUi.Available.fullHash` no lo lee ningún código de producción: `ProfileScreen`

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -96,6 +96,10 @@ three workflows and this doc all invoke it.
 suites, Android lint on the dev variant, and the iOS compile. To change what the gate means, edit
 the plugin; everything downstream follows.
 
+One task is named rather than matched: `:build-logic:test`. `build-logic` is an **included build**,
+so task-name matching never reaches it — the root project applies `justchill.quality.gate` for that
+one line and nothing else.
+
 Two properties worth knowing:
 
 - **The iOS compile is host-gated.** Kotlin/Native only builds iOS binaries on macOS, so the gate

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -96,9 +96,12 @@ three workflows and this doc all invoke it.
 suites, Android lint on the dev variant, and the iOS compile. To change what the gate means, edit
 the plugin; everything downstream follows.
 
-One task is named rather than matched: `:build-logic:test`. `build-logic` is an **included build**,
-so task-name matching never reaches it — the root project applies `justchill.quality.gate` for that
-one line and nothing else.
+"Per module" means the five in `settings.gradle.kts`. `build-logic` is an **included build**, not a
+module, so task-name matching never reaches it: one task is named rather than matched,
+`:build-logic:test`, and the root project applies `justchill.quality.gate` for that line and nothing
+else. Tests only — `build-logic` applies no detekt (its build file applies just `kotlin-dsl`; the
+detekt entry there is an `implementation` marker so `DetektConventionPlugin` can be *written*), so
+its own sources are the one body of code the gate runs and never lints.
 
 Two properties worth knowing:
 

--- a/presentation/CLAUDE.md
+++ b/presentation/CLAUDE.md
@@ -35,7 +35,10 @@ declaration becomes a lie.
 UiState + Intent + Effect + `toUi` mappers) and one Koin module in `hh/di/`; pure helpers and
 `UiStrings` sit in `hh/shared/`.
 
-`androidMain/` holds one actual, `core/sync/ResumeEvents.android.kt`. `iosMain/` holds its
+`androidMain/` holds two files: the one actual, `core/sync/ResumeEvents.android.kt`, and
+`core/CommitHash.kt` — an ordinary Android-only DI contract (producer and consumer are both
+Android), deliberately outside `commonMain` so it never reaches the iOS compile or `JustChillKit`.
+`iosMain/` holds its
 counterpart, `KoinIos.kt` — the iOS entry point (`initKoin`, `iosPlatformModule`, and one typed
 resolver per Swift-facing ViewModel) — and, unlike `androidMain`, two ordinary port implementations
 that Android satisfies from `:androidApp` instead: `PrintlnSyncLogger` for `SyncLogger` and

--- a/presentation/src/androidHostTest/kotlin/com/emm/justchill/core/AppGraphKoinTest.kt
+++ b/presentation/src/androidHostTest/kotlin/com/emm/justchill/core/AppGraphKoinTest.kt
@@ -52,7 +52,7 @@ import kotlin.time.Instant
  * `androidPlatformModule` in `:androidApp`, `iosPlatformModule` in `iosMain` — are not on this
  * source set's classpath and are never loaded, so nothing in this file says anything about what
  * they bind. A binding only they carry is guarded where it lives: `AndroidPlatformModuleTest`
- * (`:androidApp`) does that for `named("commitHash")`, which `AppNavHost` resolves at launch. An
+ * (`:androidApp`) does that for [CommitHash], which `AppNavHost` resolves at launch. An
  * assertion written here against [testPlatformModule]'s own literal would only be the fixture
  * checking itself — that is exactly what this test used to do.
  */

--- a/presentation/src/androidHostTest/kotlin/com/emm/justchill/core/TestPlatformModule.kt
+++ b/presentation/src/androidHostTest/kotlin/com/emm/justchill/core/TestPlatformModule.kt
@@ -31,10 +31,10 @@ import org.koin.dsl.onClose
  * and is not part of `appModules()`. `iosPlatformModule` omits it for the same reason, so binding it
  * here would assert wiring that no shared consumer resolves.
  *
- * `named("commitHash")` is absent for the same reason. It is resolved by `AppNavHost` in
- * `:ui-android`, outside `appModules()`, so binding it here would have asserted nothing about the
- * production binding in `androidPlatformModule` — a module this source set cannot even import.
- * That binding is guarded by `AndroidPlatformModuleTest` in `:androidApp`, where it lives.
+ * [CommitHash] is absent for the same reason. It is resolved by `AppNavHost` in `:ui-android`,
+ * outside `appModules()`, so binding it here would have asserted nothing about the production
+ * binding in `androidPlatformModule` — a module this source set cannot even import. That binding is
+ * guarded by `AndroidPlatformModuleTest` in `:androidApp`, where it lives.
  */
 val testPlatformModule: Module = module {
 

--- a/presentation/src/androidMain/kotlin/com/emm/justchill/core/CommitHash.kt
+++ b/presentation/src/androidMain/kotlin/com/emm/justchill/core/CommitHash.kt
@@ -20,24 +20,18 @@ import kotlin.jvm.JvmInline
  * string either side can misspell. That is the whole of it — see `AppNavHost`'s injection site for
  * what this does NOT stop.
  *
- * ### Why it lives here
+ * ### Why it lives here, and in androidMain
  *
- * `:presentation` is where this project's DI contracts live (see [SupabaseConfig] next door), and
- * it is the one module both `:androidApp` and `:ui-android` can see — `ui-android/build.gradle.kts`
- * exposes it with `api(project(":presentation"))`. commonMain is compose-free, and a holder over a
- * `String` carries no Compose, `java.*` or `android.*`.
+ * `:presentation` is where this project's DI contracts live — [SupabaseConfig] is the one next
+ * door. `:ui-android` sees it through `api(project(":presentation"))`, and `:androidApp` sees it
+ * through `:ui-android`.
  *
- * ### It is NOT on the Swift surface, and that is the point of the value class
- *
- * Unlike [SupabaseConfig], which appears in the generated `JustChillKit.h` as `JCKSupabaseConfig`,
- * this type appears nowhere in it: Kotlin/Native does not export `@JvmInline value class` to
- * Obj-C, and no exported declaration references it. Checked by grepping the header after
- * `linkDebugFrameworkIosSimulatorArm64` — zero occurrences of `CommitHash`.
- *
- * Deliberate. No Swift screen shows the commit, so a `data class` here would only add a symbol to
- * `JustChillKit` that nothing on that side calls. If iOS ever needs this — a binding in
- * `KoinIos.kt`, a footer in SwiftUI — Swift will not be able to see the type, and that is the
- * moment to make it a `data class`, not a bug to debug.
+ * `androidMain` rather than `commonMain` because both sides of the contract are Android-only:
+ * `androidPlatformModule` (`:androidApp`) produces it, `AppNavHost` (`:ui-android`) consumes it,
+ * and no `iosMain` code — `KoinIos.kt` included — mentions it. Keeping it out of `commonMain`
+ * keeps it out of the Kotlin/Native compilation and out of the `JustChillKit` export. If iOS ever
+ * needs a commit footer, moving this back to `commonMain` is the first step, and it would then
+ * have to stop being a `@JvmInline value class`: Kotlin/Native does not export those to Obj-C.
  */
 @JvmInline
 value class CommitHash(val value: String)

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/core/CommitHash.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/core/CommitHash.kt
@@ -1,0 +1,31 @@
+package com.emm.justchill.core
+
+import kotlin.jvm.JvmInline
+
+/**
+ * The full 40-char sha the running build was compiled from, as a type rather than a named `String`.
+ *
+ * Produced by `androidPlatformModule` (`:androidApp`) from the generated `BuildInfo`, consumed by
+ * `AppNavHost` (`:ui-android`), which hands it to the profile footer. The value may also be
+ * `GenerateBuildInfoTask.UNKNOWN_COMMIT` — the word the generator writes when git cannot answer —
+ * so this carries whatever the build produced, unvalidated; `commitHashUi()` in `:ui-android` is
+ * what classifies it.
+ *
+ * ### Why a type and not `named("commitHash")`
+ *
+ * The producer and the consumer live in different Gradle modules, so a qualifier made the contract
+ * a string that both sides had to spell the same way. A shared constant survived a rename but not a
+ * retype: a fresh literal at either site compiled, passed the whole gate, and threw
+ * `NoDefinitionFoundException` at launch. Koin resolves this by `KClass`, so the two sides now
+ * agree through the compiler's import resolution and there is no string left to spell.
+ *
+ * ### Why it lives here
+ *
+ * `:presentation` is where this project's DI contracts live (see [SupabaseConfig] next door), and
+ * it is the one module both `:androidApp` and `:ui-android` can see —`ui-android/build.gradle.kts`
+ * exposes it with `api(project(":presentation"))`. commonMain is compose-free and exported to iOS
+ * as `JustChillKit`; a data holder over a `String` carries no Compose, `java.*` or `android.*`, so
+ * the export stays clean. iOS binds nothing here: no Swift screen shows the commit today.
+ */
+@JvmInline
+value class CommitHash(val value: String)

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/core/CommitHash.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/core/CommitHash.kt
@@ -16,16 +16,28 @@ import kotlin.jvm.JvmInline
  * The producer and the consumer live in different Gradle modules, so a qualifier made the contract
  * a string that both sides had to spell the same way. A shared constant survived a rename but not a
  * retype: a fresh literal at either site compiled, passed the whole gate, and threw
- * `NoDefinitionFoundException` at launch. Koin resolves this by `KClass`, so the two sides now
- * agree through the compiler's import resolution and there is no string left to spell.
+ * `NoDefinitionFoundException` at launch. Koin resolves this by `KClass`, so there is no longer a
+ * string either side can misspell. That is the whole of it — see `AppNavHost`'s injection site for
+ * what this does NOT stop.
  *
  * ### Why it lives here
  *
  * `:presentation` is where this project's DI contracts live (see [SupabaseConfig] next door), and
- * it is the one module both `:androidApp` and `:ui-android` can see —`ui-android/build.gradle.kts`
- * exposes it with `api(project(":presentation"))`. commonMain is compose-free and exported to iOS
- * as `JustChillKit`; a data holder over a `String` carries no Compose, `java.*` or `android.*`, so
- * the export stays clean. iOS binds nothing here: no Swift screen shows the commit today.
+ * it is the one module both `:androidApp` and `:ui-android` can see — `ui-android/build.gradle.kts`
+ * exposes it with `api(project(":presentation"))`. commonMain is compose-free, and a holder over a
+ * `String` carries no Compose, `java.*` or `android.*`.
+ *
+ * ### It is NOT on the Swift surface, and that is the point of the value class
+ *
+ * Unlike [SupabaseConfig], which appears in the generated `JustChillKit.h` as `JCKSupabaseConfig`,
+ * this type appears nowhere in it: Kotlin/Native does not export `@JvmInline value class` to
+ * Obj-C, and no exported declaration references it. Checked by grepping the header after
+ * `linkDebugFrameworkIosSimulatorArm64` — zero occurrences of `CommitHash`.
+ *
+ * Deliberate. No Swift screen shows the commit, so a `data class` here would only add a symbol to
+ * `JustChillKit` that nothing on that side calls. If iOS ever needs this — a binding in
+ * `KoinIos.kt`, a footer in SwiftUI — Swift will not be able to see the type, and that is the
+ * moment to make it a `data class`, not a bug to debug.
  */
 @JvmInline
 value class CommitHash(val value: String)

--- a/ui-android/CLAUDE.md
+++ b/ui-android/CLAUDE.md
@@ -30,10 +30,9 @@ Cross-feature: `hh/shared/` (nav host, bottom bar, atoms), `core/theme/`, `compo
 No modules here. `appModules(platformModule)` / `bootstrapAppGraph` live in `:presentation`
 (`core/AppGraph.kt`); the Android platform module lives in `:androidApp`.
 
-One exception, and it is a qualifier, not a module: `COMMIT_HASH_QUALIFIER` (`hh/profile/CommitHashUi.kt`)
-is declared here and imported by `:androidApp`'s `AndroidPlatformModule`, so producer and consumer
-read one string. It sits in a feature package rather than in `:presentation`, where the DI lives —
-tracked in `docs/PROGRESS.md`.
+No exception either: the commit-hash contract used to live here as a `COMMIT_HASH_QUALIFIER` string
+and is now `:presentation`'s `core/CommitHash.kt`, bound and resolved by type. `AppNavHost` unwraps
+it at the injection point; `hh/profile/CommitHashUi.kt` keeps only the footer's presentation state.
 
 A new feature registers
 its Koin module in `:presentation`'s `appModules()`, never here — and its ViewModel goes into

--- a/ui-android/CLAUDE.md
+++ b/ui-android/CLAUDE.md
@@ -100,8 +100,9 @@ ever stutters, check compose compiler metrics before blaming the pattern.
   `:presentation`. Pure UI logic gets a plain function next to the screen and a test here — that
   is what `commitHashUi()` is. Its sentinel still has a second copy in `build-logic`
   (`GenerateBuildInfoTask.UNKNOWN_COMMIT`), which cannot be on the app's compile classpath;
-  `CommitHashUiTest` spells that word out so retyping `UNKNOWN_COMMIT_HASH` goes red, and nothing
-  catches the reverse.
+  `CommitHashUiTest` spells that word out so retyping `UNKNOWN_COMMIT_HASH` goes red, and
+  `GenerateBuildInfoTaskTest.the sentinel is the exact word the app side spells out` pins the
+  `build-logic` side, so retyping `UNKNOWN_COMMIT` goes red too.
 
 ## Gate
 

--- a/ui-android/src/androidHostTest/kotlin/com/emm/justchill/hh/profile/CommitHashUiTest.kt
+++ b/ui-android/src/androidHostTest/kotlin/com/emm/justchill/hh/profile/CommitHashUiTest.kt
@@ -19,7 +19,9 @@ import kotlin.test.assertEquals
  * `the generator's fallback is not a hash and says so in Spanish` red.
  *
  * The other direction is NOT covered: `GenerateBuildInfoTask.UNKNOWN_COMMIT` is a third copy of
- * this word in build-logic, which has no test source set, so editing it there breaks nothing here.
+ * this word, and build-logic is not on this module's compile classpath. `GenerateBuildInfoTaskTest`
+ * does not close it either — it reads that constant rather than spelling it, so it agrees with
+ * whatever the generator says. Editing the word there still breaks nothing here.
  *
  * `BuildInfoTest` keeps the other half: that the value the generator writes is one of the two
  * shapes classified below.

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/CommitHashUi.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/CommitHashUi.kt
@@ -1,19 +1,6 @@
 package com.emm.justchill.hh.profile
 
 /**
- * Koin qualifier for the full 40-char sha the build came from.
- *
- * A constant, not a literal at each site, because the two sites live in different Gradle modules:
- * `androidPlatformModule` (`:androidApp`) binds it and `AppNavHost` (this module) resolves it. Both
- * read this one declaration, so the two strings cannot differ.
- *
- * That is all it buys. Nothing checks that either site still reads it: swapping the
- * `koinInject(named(...))` argument in `AppNavHost` for a hand-typed literal compiles, passes every
- * suite and crashes at launch. Tracked in `docs/PROGRESS.md`.
- */
-const val COMMIT_HASH_QUALIFIER: String = "commitHash"
-
-/**
  * What `generate<Variant>BuildInfo` writes when git cannot answer — a source tarball, a shallow
  * export, no git on PATH.
  *

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/CommitHashUi.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/CommitHashUi.kt
@@ -7,7 +7,8 @@ package com.emm.justchill.hh.profile
  * `GenerateBuildInfoTask.UNKNOWN_COMMIT` (build-logic, off the app's compile classpath) holds the
  * same word as a separate literal. `CommitHashUiTest` spells that word out and asserts this
  * constant classifies it as [CommitHashUi.Unavailable], so changing this value turns that test red.
- * Changing the generator's copy turns nothing red — build-logic has no test source set.
+ * Changing the generator's copy turns nothing red: `GenerateBuildInfoTaskTest` reads that constant
+ * instead of spelling it, so it moves with it.
  */
 const val UNKNOWN_COMMIT_HASH: String = "unknown"
 

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt
@@ -76,9 +76,15 @@ fun AppNavHost(modifier: Modifier = Modifier) {
         val syncController: SyncController = koinInject()
         val appVersion: String = koinInject(named("appVersion"))
         // Full sha the APK was built from; the profile footer shows the first 7 and copies all 40.
-        // androidPlatformModule (:androidApp) binds the CommitHash type this asks for. Unwrapped
-        // here, at the DI boundary: the type exists so producer and consumer cannot disagree, and
-        // everything downstream of this line is footer plumbing that only needs the characters.
+        // androidPlatformModule (:androidApp) binds the CommitHash type this asks for.
+        //
+        // What the type buys is exactly one thing: there is no string left to misspell. It does NOT
+        // make the two sides agree — `koinInject<String>()` written here compiles green and crashes
+        // at launch, the same as the old hand-typed qualifier did. The mechanism stops a typo, not
+        // a rewrite. Nothing observes this line.
+        //
+        // Unwrapped at the DI boundary: everything downstream is footer plumbing that only needs
+        // the characters.
         val commitHash: String = koinInject<CommitHash>().value
 
         // First-launch Manifesto gate: show the manifesto once, then land on startTab on every

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/shared/AppNavHost.kt
@@ -26,6 +26,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.emm.justchill.core.CommitHash
 import com.emm.justchill.core.preferences.AppPreferences
 import com.emm.justchill.core.sync.SyncController
 import com.emm.justchill.core.theme.EmmTheme
@@ -37,7 +38,6 @@ import com.emm.justchill.hh.auth.authEntries
 import com.emm.justchill.hh.category.categoryEntries
 import com.emm.justchill.hh.home.homeEntries
 import com.emm.justchill.hh.onboarding.onboardingEntries
-import com.emm.justchill.hh.profile.COMMIT_HASH_QUALIFIER
 import com.emm.justchill.hh.profile.profileEntries
 import com.emm.justchill.hh.recurring.recurringEntries
 import com.emm.justchill.hh.report.reportEntries
@@ -76,10 +76,10 @@ fun AppNavHost(modifier: Modifier = Modifier) {
         val syncController: SyncController = koinInject()
         val appVersion: String = koinInject(named("appVersion"))
         // Full sha the APK was built from; the profile footer shows the first 7 and copies all 40.
-        // androidPlatformModule (:androidApp) binds it under the same COMMIT_HASH_QUALIFIER
-        // declaration. Keep the constant here: no test observes this line, so a literal typed in
-        // its place compiles green and crashes at launch. Tracked in docs/PROGRESS.md.
-        val commitHash: String = koinInject(named(COMMIT_HASH_QUALIFIER))
+        // androidPlatformModule (:androidApp) binds the CommitHash type this asks for. Unwrapped
+        // here, at the DI boundary: the type exists so producer and consumer cannot disagree, and
+        // everything downstream of this line is footer plumbing that only needs the characters.
+        val commitHash: String = koinInject<CommitHash>().value
 
         // First-launch Manifesto gate: show the manifesto once, then land on startTab on every
         // subsequent launch.


### PR DESCRIPTION
Closes three debt items left behind by the build-time commit-hash feature (PR #77). Six commits, each reviewable alone.

## 1 — the DI contract is a type, not a string

`AndroidPlatformModule` bound `named(COMMIT_HASH_QUALIFIER)` and `AppNavHost` read it back. A shared constant made a *rename* compile-safe, but a retyped literal at either site compiled, passed the whole gate, and crashed the app at launch.

It is now a `CommitHash` type, bound and resolved by type. There is no string left to misspell.

Stated narrowly on purpose: this stops a **typo**, not a **rewrite**. `koinInject<String>()` written at that line still compiles green and still crashes at launch, and nothing observes it — closing that would need a Compose-runtime test `:ui-android` does not have. The code comment says exactly this rather than claiming the two sides "cannot disagree".

The type lives in `presentation/src/androidMain`. It went to `commonMain` first, and the review caught that: producer and consumer are both Android-only, so `androidMain` keeps it out of the Kotlin/Native compilation entirely — which deleted eleven lines of KDoc that existed only to explain why a `@JvmInline value class` never reaches the exported Obj-C surface. Verified against the artifact, not the exit code: `CommitHash` appears zero times in all three generated `JustChillKit.h` files, while `SupabaseConfig` appears eight.

Side effect: `hh/profile/CommitHashUi.kt` is down to one reason to change, closing a fourth debt item.

## 2 — the convention plugin is idiomatic Gradle

`BuildInfoConventionPlugin` declared no marker for the AGP application plugin and called `extensions.configure<ApplicationAndroidComponentsExtension>` eagerly inside `apply()`, so it depended on the order of the `plugins { }` block. Now: marker declared, and the body deferred behind `pluginManager.withPlugin("com.android.application")`.

Proven in both directions. With the old code, moving `id("justchill.build.info")` above the AGP alias fails with `Extension of type 'ApplicationAndroidComponentsExtension' does not exist`. With the new code, the same reorder builds and generates correctly.

Deferring cost the loud failure, so it was restored deliberately: applying the plugin to a non-application module now fails with `The justchill.build.info plugin generates BuildInfo.kt through the Android APPLICATION variant API, but :domain never applied 'com.android.application', so nothing was registered and no BuildInfo.kt exists.` A second silent path — `variant.sources.kotlin?.` skipping the source-directory wiring — is now a `checkNotNull`.

## 3 — `build-logic` has tests, and they are on the gate

`normalizeCommitHash` is the only barrier between `git rev-parse HEAD` and a Kotlin string literal, and it had no test — `build-logic` had no test source set at all. It now has nine cases covering the accept path, uppercase normalisation, whitespace, and rejection of quotes, backslashes, `$`, newlines, a `-dirty` suffix and the empty string.

`:build-logic:test` runs under `./gradlew qualityGate`, named explicitly on the root project because an included build is unreachable by task-name matching. Configuration cache still reuses across runs.

One of those tests closes a debt item that a comment had declared unclosable: it pins the `"unknown"` sentinel's spelling with a literal assertion, the same technique the `:ui-android` side already used. Both sides are now pinned by a test that spells the word out.

## Verification

`./gradlew qualityGate --rerun-tasks` green from scratch, 245 tasks, including the macOS-only iOS compile and link. `./gradlew assembleDevDebug` green. Every claim above was proven by running the mutation and checking which test went red, not by inspection.

## Review history

Writer → Opus reviewer → fix, then Judgment Day: two blind Opus judges, a bounded fix round, and an independent final verification that re-ran every mutation itself. Zero `CRITICAL`, zero contradictions between judges.

The final verification returned `ESCALATED` on documentation only — the commit that moved `CommitHash` left `PROGRESS.md` still naming `commonMain`, and re-stated in a module doc the exact kind of unbacked "nothing catches this" claim that one of the ledger items existed to kill. Those six lines are fixed in the last commit.

## Debt still open, recorded in `docs/PROGRESS.md`

- `generate()`'s string template has no test: deleting the quotes around the interpolated value reddens nothing in `build-logic`. Closing it needs a `ProjectBuilder`/`GradleRunner` invocation against a temp dir. Chosen omission, not an oversight.
- `build-logic` is on the gate for its tests only and applies no detekt, so its own sources are the one body of code the gate runs and never lints.
- Nothing observes what `AppNavHost` asks for; see the narrowing in section 1.
