### PR TITLE
docs(sync): ADR 009 — backup is a snapshot, plus the Phase 0 sign-out fix

### DIFF
--- a/.claude/skills/auditoria/SKILL.md
+++ b/.claude/skills/auditoria/SKILL.md
@@ -57,7 +57,7 @@ A local fix belongs in the finding's `fix` field; `## Plan` is only for REFACTOR
 - `## Plan` — only on REFACTORIZAR/REHACER; ordered steps, one writer unit each.
 - `## Cobertura` — required if the budget was hit OR the target is the whole project: read vs unread.
 - Persist only if the user asks or findings exceed five; else chat. Write a NEW `docs/audits/<target-slug>.md`; if it exists, do not write — report the collision, stay in chat.
-- `docs/DATE_AUDIT.md` and `docs/sync/AUDIT.md` are PRIOR audits: read-only inputs, never write targets.
+- `docs/DATE_AUDIT.md` and `docs/archive/sync/AUDIT.md` are PRIOR audits: read-only inputs, never write targets.
 - Nothing else: no reading summary, no pleasantries.
 
 ## References

--- a/.claude/skills/auditoria/references/gates.md
+++ b/.claude/skills/auditoria/references/gates.md
@@ -6,8 +6,8 @@ Read the row for the target before opening any source file.
 |---|---|---|
 | Feature / screen flow | `docs/DESIGN_SYSTEM.md`, then the screen, its ViewModel, its use cases | 15 |
 | Architecture / module | `CLAUDE.md` `## Architecture`, then that module's own `CLAUDE.md` (only `androidApp/`, `ui-android/`, `presentation/`, `domain/`, `data/` ship one; `build-logic/`, `iosApp/`, `supabase/` have none) | 20 |
-| Sync | `docs/sync/AUDIT.md` and `docs/adr/006-sync-is-backup-only-one-device-at-a-time.md` BEFORE any source file | 20 |
-| Supabase / SQLDelight migrations | `docs/sync/AUDIT.md`, then `supabase/migrations/` against the SQLDelight schema. Flag any drift — this is the class that broke production for two months (commit `72a9b03`) | 15 |
+| Sync | `docs/sync/ADR009_PLAN.md` and `docs/adr/009-backup-is-a-snapshot-not-row-replication.md` BEFORE any source file. The forensic audit is archived at `docs/archive/sync/AUDIT.md` — read it for *why*, never for what to do next | 20 |
+| Supabase / SQLDelight migrations | `docs/archive/sync/AUDIT.md`, then `supabase/migrations/` against the SQLDelight schema. Flag any drift — this is the class that broke production for two months (commit `72a9b03`) | 15 |
 | `:presentation` commonMain | the exported-iOS surface. Any `java.*` or `android.*` reference is CRITICAL; the only proof is `./gradlew :presentation:compileKotlinIosSimulatorArm64`, which the MAIN THREAD runs — the auditor reports the suspect imports it found and marks the finding UNPROVEN | 20 |
 | Dates | `docs/DATE_AUDIT.md`; live rule #7 is an injected `Clock` + `TimeZone`, neither carrying a default | 15 |
 | `.github/` pipelines | `CLAUDE.md` `## Gotchas` — pinned SHAs, the `git describe --match "v[0-9]*"` filter, secrets via `env:` | 10 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,10 @@ crossed modules. ViewModels cannot touch Compose; conventions around it (ViewMod
 
 The app is **local-first**: SQLDelight on-device is the single source of truth and the app is fully
 usable with no account and no network. **Sync is switched OFF in production since 2026-08-12**
-(`SYNC_TEMPORARILY_DISABLED`, `core/sync/SyncKillSwitch.kt:16`), under redesign as **backup only, one
-device at a time** ([ADR 006](docs/adr/006-sync-is-backup-only-one-device-at-a-time.md), superseding
-001's multi-device premise). **Read `docs/sync/AUDIT.md` before touching anything under
+(`SYNC_TEMPORARILY_DISABLED` in `core/sync/SyncKillSwitch.kt`) and is **being removed, not repaired**:
+[ADR 009](docs/adr/009-backup-is-a-snapshot-not-row-replication.md) replaces row replication with
+**snapshot backup** — the versioned JSON export, uploaded automatically — and deletes the engine while
+keeping the sync schema. **Read `docs/sync/ADR009_PLAN.md`, the single live sync doc, before touching
 `data/.../sync/` or `presentation/.../core/sync/`.**
 
 **Data flow:** `Screen` → `ViewModel` → use case → `Repository` interface → `Default{Entity}Repository` → `LocalDataSource` (SQLDelight). The use case is there **only where there is domain logic** — a pure read goes from `ViewModel` straight to the `Repository` interface. Rationale + the measurement: `docs/CODE_QUALITY.md`.
@@ -132,11 +133,12 @@ still uses JetBrains' multiplatform `lifecycle-viewmodel`, which has to compile 
 ## Docs map (`docs/`)
 
 - `PROGRESS.md` — "where are we now" plus the single open-work checklist (there is no tech-debt list here;
-  sync debt lives in `sync/AUDIT.md`). **Read it first.**
-- `sync/AUDIT.md` — the consolidated sync audit. **Read before touching sync**, and before assuming
-  anything about the Supabase project. `sync/PLAN.md` — the original slice plan, **paused**.
+  sync debt lives in `sync/ADR009_PLAN.md`). **Read it first.**
+- `sync/ADR009_PLAN.md` — the single live sync doc: the build order replacing row replication with
+  snapshot backup. **Read before touching sync.** Old audit + slice plan sit in `archive/sync/`, kept
+  for the reasoning, never for what to do next.
 - `adr/` — filenames state the decision. 004 amends 002; 005 supersedes 003's frozen-UI scope; 006
-  supersedes 001's multi-device premise and leaves 004 dormant; 007 amends 003's point 5 (writer + reviewer, repo-wide); 008 moves the category/type invariant into the schema. **Read before changing anything an ADR decided** — ADRs are amended by a new ADR, never rewritten.
+  supersedes 001's multi-device premise and leaves 004 dormant; 007 amends 003's point 5 (writer + reviewer, repo-wide); 008 moves the category/type invariant into the schema; 009 is the one to read first for anything sync-shaped — backup becomes a snapshot, the engine goes, the schema stays; it supersedes parts of 001 and 006 and renders 002 dormant, decision by decision in its header. **Read before changing anything an ADR decided** — ADRs are amended by a new ADR, never rewritten.
 - `DATE_AUDIT.md` — the 13 date findings, all closed. **Read before touching dates.** Live rule #7:
   whatever asks "what day/month is it" takes an injected `Clock` **and** `TimeZone`, **neither carrying a
   default** (`hh/di/SharedModule.kt` is the only way in). Follow-up: #5 phase two.

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/profile/ProfileViewModelImportTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/profile/ProfileViewModelImportTest.kt
@@ -164,7 +164,7 @@ class ProfileViewModelImportTest {
         vm.onIntent(ProfileIntent.ImportJson("{}"))
         advanceUntilIdle()
 
-        // The guard no longer swallows silently (docs/sync/AUDIT.md §8) — it still runs no import,
+        // The guard no longer swallows silently (docs/archive/sync/AUDIT.md §8) — it still runs no import,
         // but it now reports through the shared OperationInProgress notify.
         assertTrue(
             effects.singleOrNull() == ProfileEffect.Notify(ProfileMessage.OperationInProgress),

--- a/androidApp/src/test/kotlin/com/emm/justchill/hh/profile/ProfileViewModelTest.kt
+++ b/androidApp/src/test/kotlin/com/emm/justchill/hh/profile/ProfileViewModelTest.kt
@@ -5,6 +5,7 @@ import com.emm.domain.auth.AuthUser
 import com.emm.domain.auth.DeleteUserAccountUseCase
 import com.emm.domain.auth.ObserveSessionUseCase
 import com.emm.domain.auth.SessionStatus
+import com.emm.domain.auth.SignOutResult
 import com.emm.domain.auth.SignOutUseCase
 import com.emm.domain.category.CategoryRepository
 import com.emm.domain.shared.backup.BackupRepository
@@ -116,24 +117,50 @@ class ProfileViewModelTest {
     }
 
     @Test
-    fun `SignOut intent invokes SignOutUseCase and emits SessionClosed notify effect`() = runTest(testDispatcher) {
-        coEvery { signOut.invoke() } returns Unit
+    fun `SignOut intent invokes SignOutUseCase and emits SessionClosed notify effect on Revoked`() =
+        runTest(testDispatcher) {
+            coEvery { signOut.invoke() } returns SignOutResult.Revoked
 
-        val vm = buildViewModel()
-        val effects = mutableListOf<ProfileEffect>()
-        val job = launch { vm.effect.collect { effects.add(it) } }
+            val vm = buildViewModel()
+            val effects = mutableListOf<ProfileEffect>()
+            val job = launch { vm.effect.collect { effects.add(it) } }
 
-        vm.onIntent(ProfileIntent.SignOut)
-        advanceUntilIdle()
+            vm.onIntent(ProfileIntent.SignOut)
+            advanceUntilIdle()
 
-        coVerify(exactly = 1) { signOut.invoke() }
-        assertTrue(
-            effects.any { it is ProfileEffect.Notify && it.message == ProfileMessage.SessionClosed },
-            "Expected SessionClosed notify not found in $effects",
-        )
+            coVerify(exactly = 1) { signOut.invoke() }
+            assertTrue(
+                effects.any { it is ProfileEffect.Notify && it.message == ProfileMessage.SessionClosed },
+                "Expected SessionClosed notify not found in $effects",
+            )
 
-        job.cancel()
-    }
+            job.cancel()
+        }
+
+    @Test
+    fun `SignOut intent emits SessionClosedLocallyOnly notify effect on LocalOnly, not SessionClosed`() =
+        runTest(testDispatcher) {
+            coEvery { signOut.invoke() } returns SignOutResult.LocalOnly
+
+            val vm = buildViewModel()
+            val effects = mutableListOf<ProfileEffect>()
+            val job = launch { vm.effect.collect { effects.add(it) } }
+
+            vm.onIntent(ProfileIntent.SignOut)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { signOut.invoke() }
+            assertTrue(
+                effects.any { it is ProfileEffect.Notify && it.message == ProfileMessage.SessionClosedLocallyOnly },
+                "Expected SessionClosedLocallyOnly notify not found in $effects",
+            )
+            assertTrue(
+                effects.none { it is ProfileEffect.Notify && it.message == ProfileMessage.SessionClosed },
+                "LocalOnly must not produce the SessionClosed (clean-revoke) notify: $effects",
+            )
+
+            job.cancel()
+        }
 
     @Test
     fun `SignOut failure emits ShowError effect`() = runTest(testDispatcher) {
@@ -274,7 +301,7 @@ class ProfileViewModelTest {
             vm.onIntent(ProfileIntent.ExportRequested)
             advanceUntilIdle()
 
-            // The guard no longer swallows silently (docs/sync/AUDIT.md §8) — it still runs no
+            // The guard no longer swallows silently (docs/archive/sync/AUDIT.md §8) — it still runs no
             // export, but it now reports through the shared OperationInProgress notify.
             assertTrue(
                 effects.singleOrNull() == ProfileEffect.Notify(ProfileMessage.OperationInProgress),
@@ -360,7 +387,7 @@ class ProfileViewModelTest {
     }
 
     /**
-     * `docs/sync/AUDIT.md` §8, candidate 1: the `launchOp` guard used to return silently on a
+     * `docs/archive/sync/AUDIT.md` §8, candidate 1: the `launchOp` guard used to return silently on a
      * confirmed re-entry — indistinguishable on screen from the delete_account RPC never firing at
      * all. It now reports instead of swallowing, still invokes the use case exactly once, and
      * resets `op` once the in-flight call completes.

--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Kotlin Multiplatform library (`android` + `iosArm64` + `iosSimulatorArm64`). Implements `:domain`
 repository interfaces. SQLDelight is the local source of truth; Supabase (`supabase-kt`) backs the
-optional auth (`auth/`) and multi-device sync (`sync/`) implementations.
+optional auth (`auth/`) and the sync engine (`sync/`) — scheduled for deletion, see below.
 
 Root package: `com.emm.data.<entity>`. `minSdk = 26`. Depends on `:domain` only.
 
@@ -74,7 +74,7 @@ in `docs/PROGRESS.md`; it does not fail the gate.
 - This module also `api`-exposes the Supabase auth/postgrest SDK and the Ktor engines. The consumer
   that actually uses them is `:presentation` (`hh/di/SupabaseModule.kt`).
 
-## Sync engine (`sync/`)
+## Sync engine (`sync/`) — scheduled for deletion, see `docs/sync/ADR009_PLAN.md`
 
 - The per-table push/pull algorithm lives once in `BaseTableSync<DTO : SyncRowDto>` (template
   method); each table class (`AccountTableSync`, etc.) supplies only generated-query adapters and

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -44,6 +44,11 @@ kotlin {
             implementation(libs.junit)
             // JVM in-memory SQLite for DB-integration unit tests (JdbcSqliteDriver).
             implementation(libs.sqlite.driver)
+            // Ktor MockEngine: lets DefaultAuthRepositorySignOutTest build a REAL SupabaseClient
+            // whose transport is scripted. Mocking the Auth plugin instead would only prove what
+            // this repository calls, not what the provider does to the session — and the provider's
+            // behaviour is the whole finding.
+            implementation(libs.ktor.client.mock)
         }
         // Instrumented tests run against the REAL AndroidSqliteDriver — that is the whole point for
         // the migration tests, which a JVM driver cannot exercise faithfully.

--- a/data/src/androidHostTest/kotlin/com/emm/data/auth/DefaultAuthRepositorySignOutTest.kt
+++ b/data/src/androidHostTest/kotlin/com/emm/data/auth/DefaultAuthRepositorySignOutTest.kt
@@ -1,0 +1,298 @@
+package com.emm.data.auth
+
+import com.emm.domain.auth.SignOutResult
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.minimalConfig
+import io.github.jan.supabase.auth.user.UserInfo
+import io.github.jan.supabase.auth.user.UserSession
+import io.github.jan.supabase.createSupabaseClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import io.github.jan.supabase.auth.status.SessionStatus as SupabaseSessionStatus
+
+/**
+ * What [DefaultAuthRepository.signOut] does to the LOCAL session depending on whether the
+ * server-side revoke can be reached, against a REAL [SupabaseClient] over a [MockEngine]. Mocking
+ * [Auth] instead would only assert what this repository calls; the finding this pins is about what
+ * supabase-kt itself does — see [DefaultAuthRepository.signOut]'s KDoc — so the provider has to be
+ * real.
+ *
+ * Three distinct transport shapes are covered on top of the happy path, because each exercises a
+ * different branch of [DefaultAuthRepository.signOut]:
+ * - **fails instantly** — an unreachable host, the ordinary offline case. Swallowed by the method's
+ *   `catch (e: Exception)`.
+ * - **hangs, and the request times out** — a connection that is accepted but never answered.
+ *   supabase-kt's own request timeout fires as an ordinary `HttpRequestTimeoutException`, an
+ *   `IOException`, not a [kotlinx.coroutines.CancellationException] — so this ALSO lands in
+ *   `catch (e: Exception)`, not the cancellation branch. This is NOT a duplicate of the case above:
+ *   `KtorSupabaseHttpClient.request` catches three things in order — `HttpRequestTimeoutException`
+ *   rethrown RAW, [CancellationException] rethrown RAW, and every remaining `Exception` wrapped into
+ *   `HttpRequestException`. Only the third arm produces the wrapped type, so narrowing the
+ *   repository's `catch (e: Exception)` to `catch (e: HttpRequestException)` would keep the
+ *   unreachable-host test green and turn this one red. That mutant is the reason it exists. The test
+ *   overrides the timeout to 500ms so it costs half a second instead of supabase-kt's 10s default;
+ *   that override is what is pinned, not the default.
+ * - **hangs, and the coroutine itself is cancelled** — the one shape the two tests above cannot
+ *   produce. This is what exercises `catch (e: CancellationException) { throw e }`: without it, a
+ *   cancellation would be indistinguishable from "the revoke failed" and get swallowed into a
+ *   [SignOutResult.LocalOnly] instead of propagating.
+ *
+ * The request timeout is therefore a per-test choice, never a shared default: see
+ * [SHORT_REQUEST_TIMEOUT] and [NON_COMPETING_REQUEST_TIMEOUT].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultAuthRepositorySignOutTest {
+
+    // supabase-kt's Auth plugin builds its coroutine scope on Dispatchers.Main, which does not
+    // exist on a JVM host test until it is set.
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `signOut clears the local session and reports LocalOnly when the network is unreachable`() = runTest {
+        val client = offlineClientWithSession()
+        val repository = DefaultAuthRepository(client)
+
+        val result = repository.signOut()
+
+        assertEquals(SignOutResult.LocalOnly, result)
+        assertTrue(
+            client.auth.sessionStatus.value is SupabaseSessionStatus.NotAuthenticated,
+            "The local clear runs unconditionally — it must happen whether or not the server-side " +
+                "revoke succeeded.",
+        )
+        assertNull(client.auth.currentSessionOrNull())
+    }
+
+    @Test
+    fun `signOut clears the local session and reports LocalOnly when the logout request hangs`() = runTest {
+        val client = hangingClientWithSession(requestTimeout = SHORT_REQUEST_TIMEOUT)
+        val repository = DefaultAuthRepository(client)
+
+        val result = repository.signOut()
+
+        assertEquals(SignOutResult.LocalOnly, result)
+        assertTrue(
+            client.auth.sessionStatus.value is SupabaseSessionStatus.NotAuthenticated,
+            "A logout post that never answers must not keep the local clear from running.",
+        )
+        assertNull(client.auth.currentSessionOrNull())
+    }
+
+    @Test
+    fun `signOut reports Revoked and clears the session when the server-side revoke succeeds`() = runTest {
+        val client = respondingClientWithSession()
+        val repository = DefaultAuthRepository(client)
+
+        val result = repository.signOut()
+
+        assertEquals(SignOutResult.Revoked, result)
+        assertTrue(client.auth.sessionStatus.value is SupabaseSessionStatus.NotAuthenticated)
+        assertNull(client.auth.currentSessionOrNull())
+    }
+
+    /**
+     * Pins the `catch (e: CancellationException) { throw e }` branch in
+     * [DefaultAuthRepository.signOut] — the thing that keeps a coroutine cancellation (app process
+     * teardown, a caller's own timeout, a screen leaving composition) from being mistaken for "the
+     * server-side revoke failed" and swallowed into a normal [SignOutResult.LocalOnly] that also
+     * clears the session.
+     *
+     * Neither of the two tests above can exercise that branch: the instantly-failing transport
+     * throws [IOException] (not cancellation), and the hanging transport's own request timeout
+     * produces [io.ktor.client.plugins.HttpRequestTimeoutException] — an ordinary [IOException]
+     * subtype, not [CancellationException] either (see [hangingClientWithSession]'s KDoc). This test
+     * cancels the coroutine itself while it is suspended inside the mocked request, using a
+     * `CompletableDeferred` to synchronize on that exact suspension point instead of racing a real
+     * delay.
+     *
+     * It also builds its transport with [NON_COMPETING_REQUEST_TIMEOUT], not the 500ms the
+     * hanging-transport test above uses. Sharing that 500ms made this test a wall-clock race against
+     * real [Dispatchers.IO] threads: ktor arms its timeout killer inside the `Send` phase, BEFORE
+     * the engine handler runs, so the half second had to cover engine dispatch, the mocked handler
+     * starting, [CompletableDeferred.complete], this coroutine resuming from `await()` and
+     * `cancel()` executing. Whenever that overran, the timeout won, the swallow path ran instead of
+     * the cancellation path, and the test failed for a reason that has nothing to do with the code
+     * under test. With a timeout that does not compete, cancellation is the only thing that can end
+     * the request, and the outcome no longer depends on how loaded the machine is.
+     *
+     * The discriminating assertion below is deliberately NOT "does `deferred.await()` throw" —
+     * verified empirically (by running this exact mutation) that it is not: cancelling a coroutine's
+     * own `Job` forces its completion to report as cancelled to `.await()` regardless of what the
+     * coroutine body does internally afterward, so `.await()` throws [CancellationException] under
+     * BOTH the correct code and the mutant below. What differs is a side effect: the correct code's
+     * rethrow exits the `try` before `client.auth.clearSession()` is ever reached, so the session is
+     * left untouched; the mutant swallows the exception and keeps going, and `clearSession()`'s
+     * in-memory implementation (from `minimalConfig()`) does not itself check for cancellation, so it
+     * runs to completion and clears the session anyway. That is the assertion this test lives or
+     * dies on.
+     *
+     * Mutation-verified: deleting the two lines `catch (e: CancellationException) { throw e }` from
+     * [DefaultAuthRepository.signOut] makes this test fail on the session-status assertion — the
+     * session ends up `NotAuthenticated` instead of staying `Authenticated`.
+     */
+    @Test
+    fun `signOut propagates CancellationException instead of swallowing it and clearing the session`() = runTest {
+        val requestStarted = CompletableDeferred<Unit>()
+        val client = hangingClientWithSession(
+            requestTimeout = NON_COMPETING_REQUEST_TIMEOUT,
+            onRequestStarted = { requestStarted.complete(Unit) },
+        )
+        val repository = DefaultAuthRepository(client)
+
+        val deferred = async { repository.signOut() }
+        requestStarted.await()
+        deferred.cancel()
+
+        assertFailsWith<CancellationException> {
+            deferred.await()
+        }
+        assertTrue(
+            client.auth.sessionStatus.value is SupabaseSessionStatus.Authenticated,
+            "A propagated cancellation must short-circuit before clearSession() runs — the session " +
+                "must be left untouched, not cleared as an unintended side effect of the swallow.",
+        )
+    }
+
+    /**
+     * A client holding a valid session whose transport always fails. [IOException] is what an
+     * unreachable host produces.
+     *
+     * supabase-kt's `KtorSupabaseHttpClient.request` wraps that into `HttpRequestException` — but
+     * NOT unconditionally: `HttpRequestTimeoutException` and [CancellationException] are rethrown
+     * RAW by that same method, unwrapped, so only the remainder (this [IOException] included) becomes
+     * `HttpRequestException`. `HttpRequestException` extends `IOException` and is NOT a
+     * `RestException`, so `AuthImpl.signOut`'s `catch (e: RestException)` does not catch it — it
+     * escapes that method uncaught and is what [DefaultAuthRepository.signOut]'s own
+     * `catch (e: Exception)` swallows directly on the way to [SignOutResult.LocalOnly]. That swallow
+     * sits INSIDE the `authCall` block, so [DefaultAuthRepository]'s `toAuthDomainException()` mapper
+     * — and `DomainException.NetworkUnavailable` — are never reached on this path; they only run for
+     * a throwable that escapes all the way out to `authCall`'s own catch.
+     *
+     * `minimalConfig()` is the library's own testing preset: in-memory session and code-verifier
+     * stores, no auto-refresh, no auto-load, and — the one that matters on a JVM host test — no
+     * Android lifecycle callbacks. Without that last flag `setupPlatform` reaches
+     * `ProcessLifecycleOwner`, which needs a main Looper this test does not have.
+     *
+     * The session is then imported explicitly with `autoRefresh = false`, so the `logout` post
+     * under exercise is the ONLY request any of these tests can produce.
+     */
+    private suspend fun offlineClientWithSession(): SupabaseClient = createSupabaseClient(
+        supabaseUrl = "https://project.supabase.co",
+        supabaseKey = "test-anon-key",
+    ) {
+        httpEngine = MockEngine { throw IOException("network is unreachable") }
+        install(Auth) { minimalConfig() }
+    }.also { client ->
+        client.auth.importSession(session(), autoRefresh = false)
+    }
+
+    /**
+     * The same client, with a transport that accepts the request and never answers it.
+     *
+     * [requestTimeout] is what ends the request, absent a cancellation from outside — and it has no
+     * default here on purpose, because the two callers want opposite things from it. supabase-kt
+     * 3.7.0 installs ktor's `HttpTimeout` itself on every client it builds, custom engine included,
+     * reading it from `SupabaseClientBuilder.requestTimeout` (default 10 seconds). Setting it here
+     * only moves when the expiry lands; it does not add the mechanism. `HttpTimeout` surfaces that
+     * expiry as `HttpRequestTimeoutException`, an ordinary `IOException`, never a
+     * [CancellationException] — which is what makes the hanging-transport test unable to exercise
+     * the cancellation branch pinned separately below.
+     *
+     * [onRequestStarted] fires the instant the mocked transport receives the request, i.e. right
+     * before it suspends forever — the cancellation test uses it to synchronize on that exact
+     * suspension point instead of racing a real delay.
+     */
+    private suspend fun hangingClientWithSession(
+        requestTimeout: Duration,
+        onRequestStarted: () -> Unit = {},
+    ): SupabaseClient = createSupabaseClient(
+        supabaseUrl = "https://project.supabase.co",
+        supabaseKey = "test-anon-key",
+    ) {
+        this.requestTimeout = requestTimeout
+        httpEngine = MockEngine {
+            onRequestStarted()
+            awaitCancellation()
+        }
+        install(Auth) { minimalConfig() }
+    }.also { client ->
+        client.auth.importSession(session(), autoRefresh = false)
+    }
+
+    /** The same client, with a transport that answers the `logout` post with an ordinary 200. */
+    private suspend fun respondingClientWithSession(): SupabaseClient = createSupabaseClient(
+        supabaseUrl = "https://project.supabase.co",
+        supabaseKey = "test-anon-key",
+    ) {
+        httpEngine = MockEngine { respondOk() }
+        install(Auth) { minimalConfig() }
+    }.also { client ->
+        client.auth.importSession(session(), autoRefresh = false)
+    }
+
+    private fun session(): UserSession = UserSession(
+        accessToken = "access-token",
+        refreshToken = "refresh-token",
+        expiresIn = 3600L,
+        tokenType = "bearer",
+        user = UserInfo(id = "user-1", aud = "authenticated", email = "user@example.com"),
+    )
+
+    private companion object {
+
+        /**
+         * For the hanging-transport test, where the timeout expiry IS the mechanism under test:
+         * stands in for supabase-kt's 10s default so that test costs half a second instead of ten.
+         */
+        val SHORT_REQUEST_TIMEOUT = 500.milliseconds
+
+        /**
+         * For the cancellation test, where the timeout must NOT be what ends the request —
+         * cancellation is. That test never waits this long on the happy path, so the value is
+         * bounded from both sides rather than simply made large:
+         *
+         * - **Above the race.** ktor arms its timeout killer in the `Send` phase, before the engine
+         *   handler runs, so the window it must clear covers engine dispatch, the mocked handler,
+         *   the `CompletableDeferred` handoff and `cancel()` executing on real threads.
+         *   [SHORT_REQUEST_TIMEOUT] was demonstrably losable there; this is twenty times that, and
+         *   it also happens to be the timeout supabase-kt 3.7.0 defaults to, so the test is not
+         *   asking for anything exotic.
+         * - **Below `runTest`'s own 60s timeout.** If a future change ever stops cancellation from
+         *   ending the request, this expires first and the test fails on the session assertion in
+         *   ten seconds. Push it past sixty and the same regression degrades into an
+         *   `UncompletedCoroutinesError` that says nothing about sign-out.
+         */
+        val NON_COMPETING_REQUEST_TIMEOUT = 10.seconds
+    }
+}

--- a/data/src/androidHostTest/kotlin/com/emm/data/sync/DefaultSyncRepositoryTest.kt
+++ b/data/src/androidHostTest/kotlin/com/emm/data/sync/DefaultSyncRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.emm.domain.auth.AuthRepository
 import com.emm.domain.auth.AuthUser
 import com.emm.domain.auth.ObserveSessionUseCase
 import com.emm.domain.auth.SessionStatus
+import com.emm.domain.auth.SignOutResult
 import com.emm.domain.shared.error.DomainException
 import com.emm.domain.sync.ConflictResolver
 import com.emm.domain.sync.SyncCursorStore
@@ -82,7 +83,7 @@ class DefaultSyncRepositoryTest {
         override suspend fun signIn(email: String, password: String) = error("not used")
         override suspend fun signUp(email: String, password: String) = null
         override suspend fun signInWithGoogle(idToken: String, rawNonce: String) = error("not used")
-        override suspend fun signOut() = Unit
+        override suspend fun signOut() = SignOutResult.Revoked
         override suspend fun deleteAccount() = Unit
         override suspend fun resendConfirmationEmail(email: String) = Unit
     }
@@ -337,7 +338,7 @@ class DefaultSyncRepositoryTest {
             override suspend fun signIn(email: String, password: String) = error("not used")
             override suspend fun signUp(email: String, password: String) = null
             override suspend fun signInWithGoogle(idToken: String, rawNonce: String) = error("not used")
-            override suspend fun signOut() = Unit
+            override suspend fun signOut() = SignOutResult.Revoked
             override suspend fun deleteAccount() = Unit
             override suspend fun resendConfirmationEmail(email: String) = Unit
         }
@@ -386,7 +387,7 @@ class DefaultSyncRepositoryTest {
             override suspend fun signIn(email: String, password: String) = error("not used")
             override suspend fun signUp(email: String, password: String) = null
             override suspend fun signInWithGoogle(idToken: String, rawNonce: String) = error("not used")
-            override suspend fun signOut() = Unit
+            override suspend fun signOut() = SignOutResult.Revoked
             override suspend fun deleteAccount() = Unit
             override suspend fun resendConfirmationEmail(email: String) = Unit
         }

--- a/data/src/commonMain/kotlin/com/emm/data/auth/DefaultAuthRepository.kt
+++ b/data/src/commonMain/kotlin/com/emm/data/auth/DefaultAuthRepository.kt
@@ -4,6 +4,7 @@ import com.emm.data.shared.ioDispatcher
 import com.emm.domain.auth.AuthRepository
 import com.emm.domain.auth.AuthUser
 import com.emm.domain.auth.SessionStatus
+import com.emm.domain.auth.SignOutResult
 import com.emm.domain.shared.error.DomainException
 import com.emm.domain.shared.error.ValidationCode
 import io.github.jan.supabase.SupabaseClient
@@ -86,8 +87,41 @@ class DefaultAuthRepository(private val client: SupabaseClient) : AuthRepository
         user.toDomain()
     }
 
-    override suspend fun signOut(): Unit = authCall {
-        client.auth.signOut()
+    /**
+     * Two steps with deliberately different failure contracts — see [AuthRepository.signOut] for
+     * why. Neither step is a guarantee; what differs is which failure the caller hears about.
+     *
+     * The server-side revoke ([SignOutScope.LOCAL] — it still narrows which sessions the server
+     * invalidates even though it does not shield the caller from a network failure) is attempted
+     * and any failure of it is swallowed, then [io.github.jan.supabase.auth.Auth.clearSession] runs
+     * UNCONDITIONALLY. That call is purely local: it deletes the code verifier, deletes the stored
+     * session, stops the auto-refresh job for the current session, and sets the status to
+     * NotAuthenticated. Nothing in it can fail on network.
+     *
+     * [io.github.jan.supabase.auth.Auth.clearSession] is deliberately OUTSIDE the swallow: if the
+     * session store itself breaks, the caller has to hear about it (it still propagates through
+     * [authCall]), because the user is still signed in.
+     *
+     * Calling `clearSession` again after a successful `signOut` re-runs all of the above — it is
+     * harmless, not literally a no-op. Nothing observes the duplicate: `SessionStatus.NotAuthenticated`
+     * is a data class and the session status is a `MutableStateFlow`, which conflates equal values,
+     * so setting it to an already-equal `NotAuthenticated` a second time does not re-emit to
+     * observers. The happy path pays nothing extra for this shape only because of that conflation.
+     */
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    override suspend fun signOut(): SignOutResult = authCall {
+        val revoked = try {
+            client.auth.signOut(SignOutScope.LOCAL)
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Swallowed on purpose — see the KDoc above. The local clear below must run whether or
+            // not the server-side revoke was reachable, which is why it sits outside this try.
+            false
+        }
+        client.auth.clearSession()
+        if (revoked) SignOutResult.Revoked else SignOutResult.LocalOnly
     }
 
     override suspend fun resendConfirmationEmail(email: String): Unit = authCall {
@@ -95,11 +129,26 @@ class DefaultAuthRepository(private val client: SupabaseClient) : AuthRepository
     }
 
     /**
-     * Calls the Supabase `delete_account` RPC to remove the auth user and all remote rows,
-     * then clears the on-device session via [SignOutScope.LOCAL].
+     * Calls the Supabase `delete_account` RPC to remove the auth user and all remote rows, then
+     * ATTEMPTS to clear the on-device session via [SignOutScope.LOCAL]. The clear is not guaranteed
+     * here the way it is in [signOut] — see below.
      *
-     * [SignOutScope.LOCAL] is intentional: the auth user no longer exists on the server after
-     * the RPC, so a server-side sign-out call would fail. LOCAL clears the on-device session only.
+     * [SignOutScope.LOCAL] is intentional: it is the narrowest scope, and the auth user no longer
+     * exists on the server after the RPC. What it does NOT do is make the call local. Exactly as
+     * documented on [signOut], supabase-kt 3.7.0's `AuthImpl.signOut` posts `logout` whenever a
+     * session exists — every scope, `LOCAL` included — and catches only
+     * [io.github.jan.supabase.exceptions.RestException]. The deleted user's JWT answers 401/403/404,
+     * which sits in the provider's `SIGN_OUT_IGNORE_CODES`, so the ordinary case does reach
+     * `clearSession()`. A network failure does not: [HttpRequestException] is an `IOException`, not
+     * a `RestException`, so it escapes the provider before the clear runs and [authCall] maps it to
+     * [DomainException.NetworkUnavailable] — leaving the device holding a session for a user that no
+     * longer exists server-side.
+     *
+     * Deliberately NOT repaired with [signOut]'s swallow-then-clear shape: whether a delete whose
+     * remote half already succeeded should still report a qualified success is its own contract
+     * question, deferred to Phase 5 of `docs/sync/ADR009_PLAN.md`. And unlike [signOut], no test
+     * covers this call shape — `DefaultAuthRepositorySignOutTest` exercises [signOut] only, so the
+     * defect above is read off the provider's source rather than off a red test.
      */
     override suspend fun deleteAccount(): Unit = authCall {
         client.postgrest.rpc("delete_account")
@@ -204,17 +253,16 @@ private val VALIDATION_AUTH_CODES: Map<AuthErrorCode, ValidationCode> = mapOf(
  * UI translates.
  *
  * [SessionRequiredException] maps to [DomainException.Unauthorized] here, which diverges from
- * `DefaultSyncRepository.toSyncDomainException` (`DefaultSyncRepository.kt:157`), where the same
- * exception maps to [DomainException.NetworkUnavailable] because it can only mean "session not
- * ready yet" on that path. The delete path does gate on the session leaving
- * [com.emm.domain.auth.SessionStatus.Initializing] before this call (`DeleteUserAccountUseCase.kt:95`),
- * but it does not additionally call `observeSession.awaitInitialization()` the way
- * `DefaultSyncRepository.currentUserId()` does (`DefaultSyncRepository.kt:125`) — the guard against
- * the Kotlin/Native race documented at `DefaultSyncRepository.kt:119-124`, where postgrest reads the
- * JWT synchronously from a session `StateFlow` that is populated asynchronously. That race is still
- * open on the delete path, so this mapping can surface it as a credentials error instead of
- * something retryable. Tracked as a follow-up in `docs/PROGRESS.md`; the sync mapper is not changed
- * by this commit.
+ * `toSyncDomainException` in `DefaultSyncRepository`, where the same exception maps to
+ * [DomainException.NetworkUnavailable] because it can only mean "session not ready yet" on that
+ * path. The delete path does gate on the session leaving [com.emm.domain.auth.SessionStatus.Initializing]
+ * before this call (`resolveAuthenticatedUserId` in `DeleteUserAccountUseCase`), but it does not
+ * additionally call `observeSession.awaitInitialization()` the way `currentUserId` in
+ * `DefaultSyncRepository` does — the guard against the Kotlin/Native race documented there, where
+ * postgrest reads the JWT synchronously from a session `StateFlow` that is populated asynchronously.
+ * That race is still open on the delete path, so this mapping can surface it as a credentials error
+ * instead of something retryable. Tracked as a follow-up in `docs/PROGRESS.md`; the sync mapper is
+ * not changed by this commit.
  */
 internal fun Throwable.toAuthDomainException(): DomainException = when (this) {
     is AuthRestException -> VALIDATION_AUTH_CODES[errorCode]?.let { validationCode ->

--- a/data/src/commonMain/sqldelight/com/emm/data/4.sqm
+++ b/data/src/commonMain/sqldelight/com/emm/data/4.sqm
@@ -37,8 +37,8 @@
 --
 -- It does NOT bump `updatedAt` and does NOT set syncState = 'Pending'. Marking rows dirty is what a
 -- repair normally does so the correction propagates — but sync has been off in production since
--- 2026-08-12 and is being redesigned as backup-only, one device at a time (ADR 006), so there is no
--- second replica for a correction to reach. All it would buy is a first backup diff inflated by
+-- 2026-08-12 and is being deleted, not repaired, in favor of snapshot backup (ADR 009), so there is
+-- no second replica for a correction to reach. All it would buy is a first backup diff inflated by
 -- every row this migration touched, on the one path the owner relies on as a safety net.
 --
 -- ── AND WHAT IT LEAVES ALONE ──────────────────────────────────────────────────────────────────

--- a/data/src/commonMain/sqldelight/com/emm/data/transactions.sq
+++ b/data/src/commonMain/sqldelight/com/emm/data/transactions.sq
@@ -163,8 +163,9 @@ GROUP BY categoryId;
 -- back, and without this the parent UPDATE is refused by the composite key — which the pull reads
 -- as "the parent has not arrived yet" and answers by holding the shared cursor forever.
 --
--- No `updatedAt` bump and no syncState flip, matching 4.sqm: sync is off in production and under
--- redesign as backup-only (ADR 006), so there is no second replica for the correction to reach.
+-- No `updatedAt` bump and no syncState flip, matching 4.sqm: sync is off in production and the
+-- engine is being deleted, not repaired, in favor of snapshot backup (ADR 009), so there is no
+-- second replica for the correction to reach.
 clearCategoryOnTypeChange:
 UPDATE transactions SET categoryId = NULL WHERE categoryId = :categoryId AND type != :categoryType;
 

--- a/docs/DATE_AUDIT.md
+++ b/docs/DATE_AUDIT.md
@@ -48,6 +48,14 @@ Status legend: `[x]` closed · `[~]` partially closed · `[ ]` open.
   `data/shared/FixedPeruOffset.kt` converts both directions at the same fixed offset in the
   meantime — an interim adapter, deleted when the server column becomes text.
 
+  **Confirmed by the sync audit (2026-08-13):** `FixedPeruOffset` and `OccurredAtText` round-trip
+  losslessly — same fixed UTC-5 offset both directions, second precision — so today's `date bigint`
+  value is not itself corrupt; it is the *stored* server value that misrepresents the instant.
+  Phase two's eventual server-side conversion must therefore use **UTC-5, not
+  `AT TIME ZONE 'UTC'`**: migration `3.sqm` already converted the historical local data under the
+  UTC-5 assumption, and the server-side conversion has to agree with it or the two disagree on the
+  same instant. Full reasoning: `docs/archive/sync/AUDIT.md`, §5 Protocol table.
+
 - [x] **6. A global clock hidden in entity constructors.** `currentTimeInMillis()` was called from
   **19 sites**, including the default arguments of `TransactionInsert`, `AccountUpsert` and
   `Transaction.Empty`. An entity that reads the wall clock on construction is doing hidden I/O.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -10,10 +10,10 @@
 > escribe ya lo deja viejo, igual que pasó con el conteo de commits.
 >
 > **El sync está APAGADO en producción desde el 2026-08-12.** Kill switch
-> `SYNC_TEMPORARILY_DISABLED` en `presentation/.../core/sync/SyncKillSwitch.kt:16`. La auditoría
-> completa —el bug vivo, el forense de producción, el borrado de cuenta que nunca salió del
-> teléfono, y la decisión de producto que retira medio diseño— está en
-> [`docs/sync/AUDIT.md`](sync/AUDIT.md). Leelo antes de tocar cualquier cosa de sync.
+> `SYNC_TEMPORARILY_DISABLED` en `presentation/.../core/sync/SyncKillSwitch.kt`. El único doc vivo
+> de sync es [`docs/sync/ADR009_PLAN.md`](sync/ADR009_PLAN.md) — leelo antes de tocar cualquier cosa
+> de sync. El forense completo —causa raíz del loop, el borrado de cuenta que nunca salió del
+> teléfono— es historia y vive en [`docs/archive/sync/AUDIT.md`](archive/sync/AUDIT.md).
 >
 > Este doc se reescribió el 2026-08-08 porque quedó dos meses desactualizado y
 > se perdió toda la migración KMP. El detalle histórico previo (sprints S0-S5,
@@ -48,7 +48,7 @@ Tres tracks grandes cerrados o casi:
 | Track | Estado |
 |---|---|
 | Producto (Fases 1-5: discovery → post-v1) | ✅ cerrado, docs en `docs/` |
-| Local-first sync (slices 1-5) | ⏸ **apagado y en rediseño** desde el 2026-08-12 — `docs/sync/AUDIT.md` |
+| Local-first sync (slices 1-5) | ⏸ apagado desde el 2026-08-12 y **en eliminación**, no en reparación — ADR 009 lo reemplaza por respaldo snapshot; plan en `docs/sync/ADR009_PLAN.md` |
 | Migración KMP / Compose Multiplatform | ✅ completa y mergeada a trunk |
 | Auditoría de funcionalidades | ✅ cerrada — 4 CRÍTICOS, 4 ALTOS, 3 MEDIOS |
 | iOS nativo SwiftUI sobre el core KMP | ⏳ S1-S2 de 11 ✅ — plan en `docs/swiftui/PLAN.md`, ADR 005 |
@@ -105,13 +105,20 @@ diciendo lo mismo se desincronizan, que es exactamente cómo este doc se rompió
 Medido el 2026-08-11 contra el código, no copiado de la versión anterior de este doc. La sección de
 sync y las dos correcciones marcadas se agregaron el 2026-08-12.
 
-### Sync — apagado en producción, en rediseño
+### Sync — apagado en producción, y en eliminación
 
-Apagado el 2026-08-12 por un loop de sync en producción. **El sync es BACKUP, no replicación: un
-device a la vez.** Eso retira `ConflictResolver`, el upsert condicional del server y todo el
-arbitraje de conflictos. La causa raíz, el forense de los dos tenants, los ~25 hallazgos vivos y el
-plan por fases están en [`docs/sync/AUDIT.md`](sync/AUDIT.md) — acá va solo qué falta, y si esta
-lista y el AUDIT se contradicen, gana el AUDIT.
+Apagado el 2026-08-12 por un loop de sync en producción. Desde el 2026-08-13,
+[ADR 009](adr/009-backup-is-a-snapshot-not-row-replication.md) decide que **el respaldo es un
+snapshot, no replicación de filas**: se sube el export JSON completo y versionado, y el motor de
+replicación se **borra** — el schema de sync se queda. ADR 006 había declarado "backup, no
+replicación" y dejado el motor en su lugar; de esa costura salió todo lo posterior.
+
+El orden de construcción por fases, las trampas verificadas, las compuertas de cada fase, el forense
+de los dos tenants y los hallazgos que sobreviven al motor están en
+[`docs/sync/ADR009_PLAN.md`](sync/ADR009_PLAN.md), el único doc vivo de sync. La causa raíz del loop
+y el resto de la maquinaria retirada quedan en
+[`docs/archive/sync/AUDIT.md`](archive/sync/AUDIT.md): donde el archivo y ADR 009 se contradigan,
+gana el ADR.
 
 - [x] Fase 0: qué apareció en pantalla al presionar borrar la cuenta. Resuelto **sin identificar
   cuál de los cuatro candidatos disparó** — el autor no lo recuerda, y el binario original de "nada
@@ -124,15 +131,28 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   AUDIT §8.
 - [x] Fase 0: que el borrado reporte su falla; rama faltante de `SessionRequiredException` en
   `toAuthDomainException`. AUDIT §8.
+- [ ] `DefaultAuthRepository.deleteAccount()` tiene el mismo defecto que Fase 0 corrigió en
+  `signOut()`: llama `client.auth.signOut(SignOutScope.LOCAL)` sin capturar el fallo de red después
+  del RPC `delete_account`, y su propio KDoc afirma que "clears the on-device session" — falso si la
+  red cae en el medio. No corregido en Fase 0 a propósito; ADR 009 Fase 5 ya reescribe
+  `DeleteUserAccountUseCase`, y es ahí donde entra.
 - [ ] Fase 0: decidir qué se hace con los dos tenants. AUDIT §8, §10.
 - [ ] **Fase 1: decidir el fork de scoping por usuario** — DB por usuario, filtro `userId` en cada
   lectura, o wipe al cambiar de cuenta. Sin decidir. AUDIT §5 (Identity).
-- [ ] Fase 1: la app tiene que decir en pantalla que iniciar sesión con otro correo re-apunta el
-  backup y sube el ledger de este device ahí.
-- [ ] Fase 2 (upsert condicional del server): **despriorizado** por backup-only, no cancelado.
-- [ ] Fase 3: rediseño de bordes — tipos en `:domain`, colapsar los cuatro `*TableSync`, cursor a
-  SQLDelight. **Restricción vinculante**: cero cambios de `CREATE TABLE`, una sola migración
-  aditiva al final. AUDIT §9.
+- [ ] ADR 009 Fase 1: `recurring_movements` al formato de export (v3), con v2 congelado y el barrido
+  del import versionado. **Precondición dura** — sin esto un restore pierde los movimientos
+  recurrentes, y restaurar un archivo v1/v2 los destruye.
+- [ ] ADR 009 Fases 2-5: pipeline de snapshot, visibilidad, confianza en el restore, y recién ahí
+  desmantelar el motor. Detalle y compuertas en `docs/sync/ADR009_PLAN.md`.
+- [ ] La app tiene que decir en pantalla, antes del primer upload a una cuenta nueva, que sube el
+  ledger entero de este device ahí — incluidas las filas de una cuenta anterior, porque `signOut()`
+  no borra nada. ADR 009 Decision 5; es aviso, no diálogo de confirmación.
+- [x] ~~Fase 2 (upsert condicional del server)~~ — **cancelado** por ADR 009 Decision 2: era el
+  arreglo de un protocolo de replicación que deja de existir.
+- [x] ~~Fase 3: rediseño de bordes, colapsar los cuatro `*TableSync`, cursor a SQLDelight~~ —
+  **cancelado** por ADR 009: el motor se borra en vez de rediseñarse. La restricción vinculante de
+  AUDIT §9 (cero cambios de `CREATE TABLE`, a lo sumo una migración aditiva) sigue en pie y ahora
+  la lleva ADR 009 Decision 9, para cuando algún día se reabra sync.
 - [ ] Arreglar los hallazgos vivos que sobreviven al backup-only: cursor único para cuatro tablas,
   push sin batching (con un punto **sin verificar** sobre el timeout), livelock de
   `MAX_PULL_PAGES`, pérdida silenciosa por fecha fuera de rango, tres carreras en
@@ -148,20 +168,21 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 - [ ] `SyncMutex.withLock` no tiene timeout: un ciclo de sync trabado bloquea el borrado de cuenta
   indefinidamente (AUDIT §8, candidato 4). **Hoy es inerte** — el sync está apagado por el kill
   switch — pero hay que cerrarlo antes de reactivar el sync.
-- [ ] `toSyncDomainException` mapea `SessionRequiredException` a `NetworkUnavailable`
-  (`DefaultSyncRepository.kt:157`), mostrando "Sin conexión" para lo que en el auth path se trata
-  como un problema de sesión. Es intencional, no un olvido — el propio comentario en
-  `DefaultSyncRepository.kt:151-156` explica por qué (transitorio, no debe cerrar la sesión) — pero
-  sigue siendo una divergencia con `toAuthDomainException` (AUDIT §8). Revisar y confirmar que sigue
-  siendo la divergencia deseada, no "corregirla" como si fuera un defecto.
+- [ ] `toSyncDomainException` (en `DefaultSyncRepository.kt`) mapea `SessionRequiredException` a
+  `NetworkUnavailable`, mostrando "Sin conexión" para lo que en el auth path se trata como un
+  problema de sesión. Es intencional, no un olvido — el comentario sobre esa rama explica por qué
+  (transitorio, no debe cerrar la sesión) — pero sigue siendo una divergencia con
+  `toAuthDomainException` (AUDIT §8). Revisar y confirmar que sigue siendo la divergencia deseada,
+  no "corregirla" como si fuera un defecto.
 - [ ] `toAuthDomainException` mapea `SessionRequiredException` a `Unauthorized` asumiendo que el
   delete path ya está gateado igual que el de sync, pero no lo está: le falta el
-  `observeSession.awaitInitialization()` que `DefaultSyncRepository.currentUserId()` sí llama
-  (`DefaultSyncRepository.kt:125`) para cerrar la carrera de Kotlin/Native documentada en
-  `DefaultSyncRepository.kt:119-124` (postgrest lee el JWT sincrónicamente de un `StateFlow` que se
-  llena async). Hoy esa carrera sigue abierta en el delete path y la nueva mapping la muestra como
-  error de credenciales en vez de algo reintentable. No se agrega `awaitInitialization()` al delete
-  path en este commit — es un cambio de comportamiento, va aparte. `DefaultAuthRepository.kt:206-217`.
+  `observeSession.awaitInitialization()` que `DefaultSyncRepository.currentUserId()` sí llama para
+  cerrar la carrera de Kotlin/Native que esa misma función documenta (postgrest lee el JWT
+  sincrónicamente de un `StateFlow` que se llena async). Hoy esa carrera sigue abierta en el delete
+  path y la nueva mapping la muestra como error de credenciales en vez de algo reintentable. No se
+  agrega `awaitInitialization()` al delete path en este commit — es un cambio de comportamiento, va
+  aparte. El razonamiento completo está en el KDoc de `toAuthDomainException`, en
+  `DefaultAuthRepository.kt`.
 
 ### Fechas — lo único abierto que toca el servidor y la data real
 
@@ -176,7 +197,7 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   solo uno es el wire de sync; el otro, leer un backup v1 de disco, es **permanente**. La fase dos
   borra un caller, no el archivo. La conversión va con UTC-5, **no** con `AT TIME ZONE 'UTC'`
   (`3.sqm` ya aplicó ese supuesto a la data histórica local): SQL ensayado en verde, 7/7 vectores,
-  falta decidir el secuenciamiento. Ver [`docs/sync/AUDIT.md`](sync/AUDIT.md) §5.
+  falta decidir el secuenciamiento. Ver [`docs/archive/sync/AUDIT.md`](archive/sync/AUDIT.md) §5.
 
 ### Release y compliance — bloqueantes del alpha, solo los puede hacer un humano
 
@@ -184,7 +205,8 @@ lista y el AUDIT se contradicen, gana el AUDIT.
   que faltaba crearlo. Es `pievwpleqmrjwszuuivr` ("Justtt"), linkeado desde el 2026-06-10
   (`supabase/.temp/linked-project.json`), con las tres migraciones aplicadas y los `prod.*`
   poblados en `supabase.properties`. La confusión no era gratuita: ese server tiene dos tenants con
-  data real y filas cruzadas. Ver [`docs/sync/AUDIT.md`](sync/AUDIT.md) §7.
+  data real y filas cruzadas. Ver [`docs/sync/ADR009_PLAN.md`](sync/ADR009_PLAN.md), sección
+  "Production forensics".
 - [ ] Hostear `docs/PRIVACY_POLICY.md` como URL pública (Play la exige para apps con eliminación
   de cuenta).
 - [ ] Completar el Google Play Data Safety form.
@@ -362,9 +384,10 @@ lista y el AUDIT se contradicen, gana el AUDIT.
 - [ ] `SyncLogger` (`domain/.../sync/SyncLogger.kt`) está nombrado para el sync path, pero ya es el
   canal general de diagnóstico: lo usan también `DeleteUserAccountUseCase` (borrado de cuenta) y
   `ClaimLocalDataOnAuthenticationUseCase` (claim al autenticarse), ninguno de los dos estrictamente
-  sync. `docs/sync/AUDIT.md:115` ya lo lista como un segundo canal de error sin tipar, paralelo a
-  `DomainException` — el nombre desalineado es la misma deuda vista desde otro ángulo. Renombrar o
-  reubicar el port toca ~18 archivos y es su propia unidad de trabajo, no se hizo acá.
+  sync. El audit archivado (`docs/archive/sync/AUDIT.md`) ya listaba `SyncLogger` como un segundo
+  canal de error sin tipar, paralelo a `DomainException` — el nombre desalineado es la misma deuda
+  vista desde otro ángulo. Renombrar o reubicar el port toca ~18 archivos y es su propia unidad de
+  trabajo, no se hizo acá.
 - [ ] `SyncOrchestrator` no tiene trigger de reconexión: si un sync falla offline y vuelve la red sin
   escrituras nuevas, no reintenta hasta el próximo `ON_RESUME`. No hay pérdida de data — local-first
   se auto-cura — solo latencia.
@@ -465,9 +488,10 @@ que después se revirtieron.
 
 ## Track: local-first sync (APAGADO — en rediseño desde el 2026-08-12)
 
-**Apagado en producción** por kill switch (`SyncKillSwitch.kt:16`), con dos gates: `AppGraph.kt:67`
-no llama a `SyncOrchestrator.start()` y `ProfileViewModel.kt:157` corta el path manual. No se borró
-nada — todo binding, test y clase del motor sigue cableado.
+**Apagado en producción** por el kill switch `SYNC_TEMPORARILY_DISABLED` (`SyncKillSwitch.kt`), con
+dos gates: `bootstrapAppGraph` en `AppGraph.kt` no llama a `SyncOrchestrator.start()`, y
+`ProfileViewModel.syncNow()` corta el path manual antes de encolar nada. No se borró nada — todo
+binding, test y clase del motor sigue cableado.
 
 Por qué: el push descartaba toda fila con un `userId` viejo mientras `countPending` las seguía
 contando, así que el trigger de escrituras debounceadas re-disparaba cada pocos segundos para
@@ -481,9 +505,9 @@ pendiente de "convergencia multi-device sin probar" que este doc arrastraba.
 Slices 1-4 ✅ shipearon (schema v3, auth opt-in + claim, motor push/pull, lifecycle); slice 5 ⏸. Ojo
 con esa lista: "verificado en device" significa **una vez, contra un stack Supabase local**, el
 2026-06-10 — el borrado de cuenta pasó esa verificación y después falló en producción sin enviar su
-RPC. Todo el detalle en [`docs/sync/AUDIT.md`](sync/AUDIT.md); lo que falta, en el
+RPC. Todo el detalle en [`docs/archive/sync/AUDIT.md`](archive/sync/AUDIT.md); lo que falta, en el
 [checklist](#sync--apagado-en-producción-en-rediseño). Decisiones en `docs/adr/001` y `002`; el plan
-de slices original en `docs/sync/PLAN.md`, **pausado**.
+de slices original en `docs/archive/sync/PLAN.md`, **cerrado por ADR 009**.
 
 Después de eso, el camino de release es `/release` → tag `vX.Y.Z` → `uploadRelease.yml`. Ese
 workflow **no publica**: sube el AAB a la pista alpha como **borrador**, con el `mapping.txt` para
@@ -582,10 +606,10 @@ siguen en el repo como marcadores históricos.
 
 - `docs/WORKFLOW.md` — loop writer/reviewer + gate + tiers de modelo, para todo el repo. **Vigente.**
   `docs/archive/kmp/ORCHESTRATION.md` — el ledger de slices de KMP + landmines. **Cerrado.**
-- `docs/sync/AUDIT.md` — **la auditoría consolidada de sync (2026-08-12)**: causa raíz, forense de
-  producción, qué retira el backup-only, forma objetivo y plan por fases. Leerlo antes de tocar sync.
-- `docs/sync/PLAN.md` — slices de sync + SQL de Supabase. **Pausado**; slices 1-4 son el registro de
-  lo que shipeó, el resto lo reemplaza `AUDIT.md`.
+- `docs/sync/ADR009_PLAN.md` — **el único doc vivo de sync**: la decisión de ADR 009 (el respaldo es
+  snapshot, no replicación), el forense de producción y el plan por fases. Leerlo antes de tocar sync.
+  La auditoría original y el plan de slices viejo quedan en `docs/archive/sync/`, para el *por qué*,
+  no para el *qué sigue*.
 - `docs/adr/` — 001 (reversa a local-first con sync opcional), 002 (cursor de pull),
   003 (iOS congelado: se mantiene solo el compile gate, se retira el ritual),
   004 (el resolver de conflictos solo arbitra ediciones sin pushear; enmienda al 002),

--- a/docs/adr/006-sync-is-backup-only-one-device-at-a-time.md
+++ b/docs/adr/006-sync-is-backup-only-one-device-at-a-time.md
@@ -21,7 +21,7 @@ That need was never exercised: there is one owner and one phone. What the multi-
 produce is the 2026-08-12 outage — a self-feeding sync loop, an account deletion that never reached
 the server, and two tenants in the cloud project with cross-referencing rows. Sync is switched off in
 production (`SYNC_TEMPORARILY_DISABLED`); the full findings are in
-[`docs/sync/AUDIT.md`](../sync/AUDIT.md).
+[`docs/archive/sync/AUDIT.md`](../archive/sync/AUDIT.md).
 
 The loop's proximate cause sits inside conflict resolution: `KeepLocal` → `markPendingForResync` is
 the only thing in the system that re-dirties an already-synced row, and it exists **only** to resolve
@@ -78,4 +78,4 @@ conflicts. Convergent bidirectional replication was built for a scenario the pro
 - ADR 002's `server_updated_at` cursor is **unaffected** — it orders pulls and never resolved
   conflicts. ADR 003/005 (iOS) are unrelated.
 - Findings, production forensics, target shape and the phased plan:
-  [`docs/sync/AUDIT.md`](../sync/AUDIT.md). Status: [`docs/PROGRESS.md`](../PROGRESS.md).
+  [`docs/archive/sync/AUDIT.md`](../archive/sync/AUDIT.md). Status: [`docs/PROGRESS.md`](../PROGRESS.md).

--- a/docs/adr/009-backup-is-a-snapshot-not-row-replication.md
+++ b/docs/adr/009-backup-is-a-snapshot-not-row-replication.md
@@ -1,0 +1,202 @@
+# ADR 009 — Backup is a snapshot, not row replication
+
+- **Status**: Accepted
+- **Date**: 2026-08-13
+- **Deciders**: Edgardo Muñoz
+- **Supersedes**: [ADR 006](006-sync-is-backup-only-one-device-at-a-time.md) Decisions 1, 5 and 6;
+  [ADR 001](001-reverse-local-only-to-local-first-optional-sync.md) Decisions 5 (dirty flag +
+  `lastPulledAt` cursor) and 8 (Supabase as a dumb LWW store). ADR 001 Decisions 1, 2, 3, 6 and 7
+  stand — 6 and 7 are actively protected by Decision 9 below; Decision 4 was already superseded by
+  ADR 006. ADR 006 Decisions 2 and 4 survive intact and are strengthened here; **ADR 006 Decision 3
+  survives, retargeted** — see Decision 5.
+- **Renders dormant**: [ADR 002](002-pull-cursor-uses-server-set-timestamp.md) in full — it orders
+  a pull, and there is no pull left to order. [ADR 004](004-conflict-resolution-only-arbitrates-unpushed-edits.md)
+  was already dormant; its rule stays on the books, but `ConflictResolver` the class is deleted
+  rather than parked (see Decision 2).
+
+> Resumen (es): el respaldo deja de ser replicación fila por fila y pasa a ser un **snapshot**: el
+> export JSON completo y versionado, subido automáticamente a Supabase Storage, con retención
+> escalonada y snapshots fijables. ADR 006 ya había declarado que el sync era "backup, no
+> replicación", pero dejó el motor de replicación en su lugar — le cambió el nombre al contrato, no
+> a la máquina, y de esa costura salieron todos los problemas posteriores. La forensia cierra la
+> discusión: toda la vida productiva del motor fueron **diez minutos** el 2026-06-11, **ningún
+> borrado llegó jamás al servidor**, y quedaron referencias colgadas entre dos inquilinos. El
+> restore ya existe y es el único camino de datos con un test de compatibilidad de formato
+> congelado. Se elimina el MOTOR de sync; el **schema** de sync se queda intacto para que reabrir
+> sync algún día no exija ninguna migración destructiva. Lo que NO se retira: un teléfono sigue
+> teniendo una sola base y ningún borrado al cambiar de cuenta, así que cambiar de destino de
+> respaldo se avisa en pantalla antes del primer upload.
+
+## Context
+
+[ADR 006](006-sync-is-backup-only-one-device-at-a-time.md) redefined sync as backup and retired the
+convergence machinery on paper. It did not remove that machinery. The product contract said
+"backup", the code kept doing bidirectional replication, and every problem since has come out of
+that seam — most recently a re-point flow whose confirmation dialog could not honestly describe
+what confirming would do, because clearing the pull cursor makes the next cycle download the
+destination account's ledger onto this device. That is a merge, and `docs/archive/sync/AUDIT.md` §5,
+the "Identity and data scoping" table, records that **no read query filters by `userId`**, so those
+foreign rows would surface in Home and Reporte.
+
+Three facts from `docs/archive/sync/AUDIT.md` §7 settle whether the engine is worth repairing:
+
+- **The engine's entire productive life is a ten-minute window.** Tenant A's 50 rows are frozen at
+  `server_updated_at` 2026-06-11 10:25:27–10:35:24. Tenant B's 14 rows are all from 2026-08-12,
+  its first sign-in ever. That is all of it.
+- **Zero rows carry a non-null `deleted_at` anywhere.** No soft delete ever reached the server, not
+  once. Half the protocol never worked in production, and that has nothing to do with the loop.
+- **Cross-tenant dangling references.** All 13 of tenant B's transactions point at an account owned
+  by tenant A; RLS hides the parents. The inserts succeeded because the public schema has no
+  foreign keys at all, deliberately, per ADR 001.
+
+The loop itself (`AUDIT.md` §3) is a genuinely small fix — two predicates that must agree and do
+not, plus a second independent path that needs no account switch at all
+(`TransactionTableSync.kt:45-52` drops any pending transaction whose `occurredAt` does not parse).
+Fixing it was considered seriously and rejected: it returns the app to the engine described above.
+
+Row-level replication earns its cost in four scenarios, and JustChill has none of them. Two
+concurrent writers: rejected by the product definition, not merely absent
+(`PRODUCT_REQUIREMENTS.md` W-04, "Multi-cuenta compartida (parejas, equipos)" —
+`§4 NO ES (es individual)`). A dataset too large to ship whole: one human's personal finances. A
+server that must read the rows: no server-side feature exists and push notifications are a
+Won't-have (W-08). Real-time between devices: there is one owner and one phone, the premise ADR 006
+already found was never exercised.
+
+Discovery had answered this before ADR 001 was written. `PRODUCT_DISCOVERY.md:301` records the
+owner's own response to "¿Algún «NO ES» te duele?" — *"Cloud/backup me tienta — pero solo como
+Export/Import JSON manual"*, resolved as *"Cloud-backend / Google Sign-In / sync siguen fuera"*.
+ADR 006's alternatives table then rejected "drop sync entirely, keep the manual JSON export"
+because the export is **a manual step the owner has to remember** — a rejection of *manual*, not of
+*export*. Automating it removes the stated objection.
+
+## Decision
+
+1. **Backup is a snapshot.** The complete versioned JSON export is uploaded to Supabase Storage:
+   one blob per snapshot, a sidecar manifest carrying its SHA-256, format version and per-table row
+   counts, and a read-back hash check before any upload is recorded as successful. Retention is
+   staggered — 7 daily, 8 weekly, 12 monthly — plus **pinned** snapshots that retention skips.
+   **The pipeline inherits the opt-in gate unchanged**: it runs only for a signed-in session, and
+   the app remains fully usable with no account and no network (ADR 001 Decisions 1 and 2; PRD
+   W-02 and W-11, which stay as written — "Backend Supabase solo se usa si el usuario activa sync
+   desde Perfil" now reads "activa el respaldo"). No session means no pipeline, not a queued
+   upload.
+2. **The row-replication engine is decommissioned, not parked.** `BaseTableSync` and the per-table
+   syncs, the pull cursor, `ConflictResolver`, LWW, `markSynced`/`markPendingForResync`, the sync
+   scheduling and its debounce are deleted. This amends ADR 006 Decision 5: keeping dead
+   convergence machinery in the tree is what allowed the contract and the code to disagree for two
+   months. Git history is the archive; ADR 004's *rule* remains readable here and in its own ADR.
+   **ADR 006 Decision 6 is cancelled, not merely deprioritized**: server-side conditional upsert
+   was the fix for a replication protocol that no longer exists.
+3. **Restore is `importFromJson`, unchanged in kind.** It is a transactional replace-all **over the
+   tables the format carries** — every live row in those tables tombstoned, then the file's rows
+   restored — and it drops, by design, rows it cannot represent: a transaction whose `occurredAt`
+   does not parse, and a `categoryId` whose type no longer matches
+   (`DefaultBackupRepository.kt:257-258`, `:302-305`). `ImportStats` deliberately reports what
+   landed, not what the file held. `recurring_movements` is not in the format today and is
+   therefore spared by the sweep; closing that is a precondition, not a follow-up (see Consequences).
+   The format is version-tagged and old shapes are frozen in their own types with fixtures pinning
+   them (`BackupV1.kt`) — the only data path in the repository with a frozen-format compatibility
+   test. It becomes the product.
+4. **Backup ships only once restore is continuously proven**: a CI round-trip test over every
+   exported table including tombstoned rows, an in-app "verify backup" that checks hash, parse and
+   per-table counts *without applying*, and a documented restore drill on the release checklist.
+   Until those pass, the pipeline stays behind its own flag.
+5. **Changing the backup destination is disclosed on screen before the first upload to it.** This
+   retargets ADR 006 Decision 3, which does not retire with the engine. `docs/archive/sync/AUDIT.md`
+   §5, the same "Identity and data scoping" table, records that `signOut()` clears the session and
+   nothing else — one SQLite file per device, no per-user database, no wipe on user change — so
+   *"the next account inherits the previous one's rows"*.
+   Under snapshots that inheritance means the next automatic upload sends **this device's whole
+   ledger, including the previous account's rows, into the new account's bucket**. That follows
+   from ADR 006 Decision 2 (the data belongs to the DEVICE; the account is only a destination) and
+   is acceptable behaviour — but only if the app says so first. It is a one-time **disclosure**,
+   not the confirm-or-cancel dialog the re-point flow needed: nothing is downloaded, nothing is
+   merged, and nothing is destroyed locally, so there is no fork to arbitrate.
+6. **Trigger rule.** *Sync is only reopened when a second concrete writer exists: a physical device
+   in daily use, or a deployed editable web surface. A plan or hypothesis does not qualify.
+   Reopening requires a new ADR that names the device and cites this rule.* This is a product
+   contract, not a technical invariant — nothing enforces it.
+7. **Restore fork rule.** *Restoring a snapshot onto a device makes that device THE device. Any
+   other device holding the data is retired at that moment; continuing to write from it forks
+   history and is unsupported.* Also a contract, not an invariant: nothing detects a second writer,
+   and under Decision 6 there is not supposed to be one.
+8. **Encryption relies on Supabase at-rest encryption. End-to-end encryption is explicitly
+   deferred**, and deferred for a reason rather than for effort: a Keystore- or Keychain-bound key
+   dies with the phone, which is the exact scenario a backup exists to survive. Doing it properly
+   means a passphrase-derived key and a recovery story for a forgotten passphrase, and that is its
+   own ADR.
+9. **The sync SCHEMA stays. Forbidden by this ADR:** dropping `userId`, `syncState` or `deletedAt`
+   from any table; changing the UUID primary keys; reverting to hard deletes — soft delete plus
+   `deletedAt IS NULL` on every read stays (ADR 001 Decisions 6 and 7, preserved). Reopening sync
+   must therefore need **no destructive migration**: at most one additive table, which is exactly
+   what `AUDIT.md` §9 "Data safety — the binding constraint" already specifies for moving cursor
+   persistence into SQLDelight. Note what the columns become: with `markSynced` and
+   `markPendingForResync` gone, every row is written `'Pending'` and nothing ever clears it, so
+   `syncState` carries no information after Phase 5 — a future engine must treat the first sync as
+   a full push rather than trusting the flag.
+
+ADR 006 Decision 2 (**the data belongs to the DEVICE; the account is only a backup destination**)
+and Decision 4 (**production is derived, never authoritative**) survive and are strengthened: under
+snapshots the account holds opaque blobs it cannot interpret, and the server is incapable of being
+authoritative because nothing reads rows out of it.
+
+## Alternatives considered
+
+| Option | Why rejected |
+|---|---|
+| **Keep the engine, fix the loop** | The smallest change on the table, and the loop fix is real (align the two predicates in `AUDIT.md` §3). It returns the app to an engine that never synced a single delete in production and left cross-tenant dangling references. The loop was the part that was visible, not the ceiling of the problem. |
+| **Push-only row sync** (upload rows, never pull) | Kills the merge semantics that broke the re-point flow, but leaves no restore path — and a backup you cannot restore from is not a backup. The only tested restore is the JSON import, so this converges on snapshots with extra machinery. |
+| **Local file backup only (SAF / iCloud), zero backend** | Genuinely attractive: it removes Supabase from the data path entirely and matches Discovery's "the app touches no server" line. Rejected because it needs the owner to keep choosing a destination and to notice when the file stops being written; that is ADR 006's "manual step the owner has to remember", relocated. Supabase Storage is chosen because auth already exists for it and RLS gives per-user isolation for free. Revisit if the Supabase dependency ever becomes the thing worth removing. |
+| **Adopt a sync engine now** (PowerSync, Turso, ElectricSQL) | These are the correct answer to *a second writer*, and there is no second writer. Priced from vendor documentation on 2026-08-13, unverified against the tree: PowerSync has a Kotlin Multiplatform SDK but its SQLDelight integration is Beta; Turso's offline sync is public beta and adopting it means moving off Supabase Postgres. Cost would not be the deciding factor at this volume — SDK maturity would. Recorded here so the trigger rule has somewhere to point; re-check before acting on it. |
+| **Keep the manual export and change nothing** | The status quo ADR 006 rejected, for the right reason: a device loss between exports is real data loss on a phone with accumulated real data. Automating the export is the whole point of this ADR. |
+| **Snapshot the raw SQLite file instead of the JSON export** | Simpler to produce and byte-exact, but it restores only into the schema version it was written from, so every migration turns old snapshots into liabilities. The JSON format already survives schema changes by design — `BackupV1` files were written against schema 3 and restore into schema 5. |
+
+## Consequences
+
+### Positive
+
+- **Snapshots survive owner mistakes; replication faithfully mirrors them.** An accidental wipe
+  propagates to the server within one sync cycle and destroys the backup. With staggered retention
+  the previous days are still there. For a feature whose entire purpose is backup, this is the
+  point, not a detail.
+- A whole class of problems retires: conflicts, cursors, tombstone propagation, LWW, clock skew,
+  and the re-point merge that could not be honestly described on screen. **Not** the identity
+  scoping findings of `AUDIT.md` §5 — see Decision 5 and the costs below.
+- **No schema migration.** The dead sync columns stay in place, so this ships without touching a
+  database that holds real accumulated data.
+- The restore path is the one that was already tested, rather than a pull path never exercised.
+
+### Negative / costs
+
+- **`recurring_movements` is not in the export format** and the row engine did cover that table.
+  Adding it (format v3) is a hard precondition, not a follow-up: shipping snapshots without it
+  would silently drop recurring movements on device loss. The import sweep must become
+  version-aware at the same time, or restoring an older v1/v2 file would destroy local recurring
+  movements.
+- **`AUDIT.md` §5 does not retire.** One SQLite file per device, no wipe on user change, and no
+  read query filtering by `userId` all survive this ADR. Decision 5 discloses the consequence
+  rather than removing it; a real fix is a schema question and is out of scope here.
+- **`SyncMutex` survives** with `DeleteUserAccountUseCase` still holding it, and the backup
+  orchestrator becomes a second holder. The missing-timeout defect recorded in `docs/PROGRESS.md`
+  therefore stays live and must be closed before the pipeline ships, not after.
+- **Point-in-time granularity.** A device lost hours after the last snapshot loses those hours.
+  Row sync would have lost less — in principle; in practice it lost everything, since no delete and
+  no row after 2026-06-11 10:35 ever reached the server.
+- **Full re-upload per snapshot.** Irrelevant at this dataset size, and it would matter if the app
+  ever grew a second user.
+- **The 25 unmerged commits on `worktree-sync-phase-1-identity` are abandoned.** They repair the
+  engine this ADR removes. Accepted knowingly: unmerged work is cheaper than a permanent
+  bidirectional replication engine.
+- ADR 001 and 002 remain on the books describing a system that no longer exists in any form. A
+  reader who stops at either gets the wrong model; this ADR has to be reached first.
+
+## Notes
+
+- **What enforces the rules above.** Decisions 6 and 7 are contracts, not invariants, and say so.
+  The retention/pinning behaviour and the version-aware import sweep are enforced by tests named in
+  the plan. "Every DB schema migration is preceded by a pinned snapshot" is enforced only by the
+  release-checklist line Decision 4 creates — if that line is not written, the rule is prose.
+- Build order, the verified traps and the phase gates: [`docs/sync/ADR009_PLAN.md`](../sync/ADR009_PLAN.md).
+- Findings, production forensics and the loop's root cause: [`docs/archive/sync/AUDIT.md`](../archive/sync/AUDIT.md).
+  `docs/archive/sync/PLAN.md` described the old engine's phased repair and is closed by this ADR.
+- Status: [`docs/PROGRESS.md`](../PROGRESS.md).

--- a/docs/archive/kmp/MIGRATION_PLAN.md
+++ b/docs/archive/kmp/MIGRATION_PLAN.md
@@ -375,4 +375,4 @@ Phase 6  iOS parity         ── sync/auth/telemetry per agreed scope
 - Wizard reference project: `~/Downloads/KotlinProject.zip`
   (unzipped audit at `/tmp/kp_extract/KotlinProject`)
 - Project ADRs: `docs/adr/001` (local-first), `docs/adr/002` (pull cursor)
-- Sync plan: `docs/sync/PLAN.md`
+- Sync plan (archived, closed by ADR 009): `docs/archive/sync/PLAN.md`

--- a/docs/archive/sync/AUDIT.md
+++ b/docs/archive/sync/AUDIT.md
@@ -1,16 +1,22 @@
 # Sync — consolidated audit
 
+> **ARCHIVED.** This is the forensic audit of the row-replication sync engine that
+> [ADR 009](../../adr/009-backup-is-a-snapshot-not-row-replication.md) deleted. Kept for *why* this
+> exists, not for what to do next: its surviving findings were absorbed into
+> [`docs/sync/ADR009_PLAN.md`](../../sync/ADR009_PLAN.md), the single live sync doc. Its `file:line`
+> citations are known-rotted — do not trust them.
+
 Sync is **off in production** since 2026-08-12 (`253e170`). This doc is the reference for the
 redesign: root cause, what the backup-only decision retires, what still has to be fixed, and what
-must survive the rewrite. Status lives in `docs/PROGRESS.md`; `docs/sync/PLAN.md` is the old slice
-plan, paused.
+must survive the rewrite. Status lives in `docs/PROGRESS.md`; `docs/archive/sync/PLAN.md` is the old
+slice plan, closed by ADR 009.
 
 All of it is static reading of code, SQL and server logs. **Nothing was executed against a device**
 except the one observation in §2. `file:line` refs were re-checked against trunk `253e170`.
 
 ## 1. The decision
 
-Recorded as [ADR 006](../adr/006-sync-is-backup-only-one-device-at-a-time.md), which supersedes ADR
+Recorded as [ADR 006](../../adr/006-sync-is-backup-only-one-device-at-a-time.md), which supersedes ADR
 001's multi-device premise and leaves ADR 004 dormant.
 
 **Sync is backup, not replication.** One device at a time; two devices never write concurrently. The
@@ -38,7 +44,7 @@ Nothing was removed; every binding, test and engine class is still wired. Profil
 "Sincronización en pausa". **The only runtime observation of the bug:** the owner signed out and the
 loop stopped — proving an authenticated-session trigger drives it, not which one. All else is static.
 
-**Changed while off (2026-08-12, schema v5 / [ADR 008](../adr/008-the-schema-owns-the-category-type-invariant.md)):**
+**Changed while off (2026-08-12, schema v5 / [ADR 008](../../adr/008-the-schema-owns-the-category-type-invariant.md)):**
 `(categoryId, type)` is a composite foreign key now, and the three pull writers had to learn it
 before it could freeze them. `TransactionTableSync` and `RecurringMovementTableSync` write a
 mismatched remote row uncategorized instead of deferring it — a mismatch does not resolve by

--- a/docs/archive/sync/PLAN.md
+++ b/docs/archive/sync/PLAN.md
@@ -1,8 +1,8 @@
 # Local-first sync — execution plan (slices 1-5)
 
 > Operational plan for the local-first-sync track. Decisions live in
-> [ADR 001](../adr/001-reverse-local-only-to-local-first-optional-sync.md)
-> and [ADR 002](../adr/002-pull-cursor-uses-server-set-timestamp.md) —
+> [ADR 001](../../adr/001-reverse-local-only-to-local-first-optional-sync.md)
+> and [ADR 002](../../adr/002-pull-cursor-uses-server-set-timestamp.md) —
 > this doc only sequences the work and carries the re-derived Supabase
 > SQL. If this doc and an ADR disagree, the ADR wins.
 >
@@ -20,13 +20,12 @@
 > `androidMain` and `androidHostTest`, no commonMain at all, and holds just the
 > Compose UI. The `SyncCursorStore` port is in `:domain`; the engine is still in `:data`.
 >
-> **⏸ PAUSED 2026-08-12 — sync is switched off in production** (`253e170`,
-> `SYNC_TEMPORARILY_DISABLED`). Do not resume the slices below as written: the
-> decision of record is now **backup only, one device at a time**, which retires
-> the conflict-convergence design this plan assumes. Read
-> [`docs/sync/AUDIT.md`](AUDIT.md) first — it carries the root cause, the
-> production forensics, and the phased plan that replaces slice 5. Slices 1-4 stay
-> as the record of what shipped.
+> **ARCHIVED — closed by [ADR 009](../../adr/009-backup-is-a-snapshot-not-row-replication.md).**
+> Sync was switched off in production 2026-08-12 (`253e170`, `SYNC_TEMPORARILY_DISABLED`); do not
+> resume the slices below as written — ADR 009 deletes the row-replication engine this plan assumes
+> and replaces it with snapshot backup. Read [`docs/sync/ADR009_PLAN.md`](../../sync/ADR009_PLAN.md),
+> the single live sync doc, for the build order that replaces slice 5. Slices 1-4 stay as the record
+> of what shipped.
 
 ## Status
 

--- a/docs/sync/ADR009_PLAN.md
+++ b/docs/sync/ADR009_PLAN.md
@@ -1,0 +1,286 @@
+# ADR 009 implementation plan — snapshot backup
+
+Replaces the row-replication sync engine with automatic snapshot backup: the complete versioned
+JSON export, uploaded periodically to Supabase Storage. One blob per snapshot, staggered retention,
+one restore path — the existing `importFromJson`.
+
+**This is the only live sync document.** The decision of record is
+[ADR 009](../adr/009-backup-is-a-snapshot-not-row-replication.md); where the two disagree, the ADR
+wins. Everything actionable is here. The engine's forensic audit and the old slice plan are
+historical and live in `docs/archive/sync/` — read them for *why* this exists, never for what to do
+next. Phase status is tracked in `docs/PROGRESS.md`, not here.
+
+**Citations are by symbol, not by line.** A line number in prose is a guarantee nothing enforces:
+six of the eight `file:line` refs inherited from the audit had already rotted by 2026-08-13. Name
+the symbol and let `rg` find it.
+
+**Base**: a new branch off `origin/trunk`. NOT `worktree-sync-phase-1-identity` — that branch's
+25 commits repair the engine this plan removes, and are abandoned (Phase 0 scanned them once for
+salvage).
+
+## Hard constraints (violating any of these is failure)
+
+1. **No DB schema migration anywhere in this plan.** Real accumulated data is on the device.
+   The export FORMAT version (v2 → v3) is not the DB schema version; new `.sq` SELECTs are fine.
+2. **Never drop** `userId` / `syncState` / `deletedAt`; never change UUID PKs; never revert to
+   hard deletes. The sync SCHEMA stays so a future engine can be plugged in without re-migrating.
+3. `SYNC_TEMPORARILY_DISABLED` stays `true` forever and is deleted only at the end of Phase 5.
+   The new pipeline ships behind its own flag, flipped only after Phase 4 passes.
+4. **No silent failure in the backup pipeline.** Every failure path logs with a distinct reason
+   (the 2026-08-12 outage was invisible because the `KeepLocal` path logged nothing).
+5. Phases land in order 0 → 1 → 2 → 3 → 4 → 5, each its own PR series with a green
+   `qualityGate` before the next starts. Phase 5 (deletion) only after 2–4 are proven, so there
+   is never a window with the old engine gone and the new backup unverified.
+
+## Inherited from the audit — what still binds
+
+The engine's audit is archived, but five of its findings survive the engine and constrain the work
+below. Everything else in it described machinery this plan deletes.
+
+| Finding | Where it lands |
+|---|---|
+| **Account inheritance.** `signOut()` clears no local data and there is one SQLite file per device, no per-user DB, no wipe on user change. So the next account inherits the previous one's rows — and under snapshot backup that ledger gets uploaded to the new account's bucket | ADR 009 Decision 5; the disclosure in Phase 3, the sign-out fix in Phase 0 |
+| **No read query filters by `userId`.** `all:`, `completeTransactions:`, `liveTotals:`, `getAccountBalance:` and `monthlyStats:` filter only `deletedAt IS NULL` | Does not retire. It is the same hazard as the row above, seen from the read side |
+| **`updateFromRemote` stamps `userId` unconditionally**, and the 23 seeded default categories carry fixed identical UUIDs on every install — so the same PKs exist on every device that ever ran the app | Phase 5 cloud cleanup: this is why the two tenants' rows cannot simply be merged |
+| **RLS is correct — preserve it.** `with check (user_id = (select auth.uid()))` on all four tables, policies `to authenticated` only; `delete_account()` is `security definer` with `set search_path = ''`, revoked from `public`/`anon`; `requireValidSession = true` in `SupabaseModule` | Phase 2b models the Storage bucket policy on it |
+| **`syncMutex.withLock` has no timeout**, and the mutex is a shared Koin `single` | Phase 3 — `BackupOrchestrator` becomes a second holder |
+
+**Production forensics (input to Phase 5, never executed).** Supabase project `pievwpleqmrjwszuuivr`,
+two tenants: `edmashaki@gmail.com` with 50 rows frozen at 2026-06-11, and `edgardo.emm20@gmail.com`
+with 14 rows from 2026-08-12. **Zero rows with a non-null `deleted_at` anywhere** — no soft delete
+ever reached production. All 13 of the second tenant's transactions point at an account owned by
+the first, as do 4 of their 5 category refs; the inserts succeeded because the public schema has no
+foreign keys at all, deliberately, per ADR 001. That is the "proven garbage" Phase 5 truncates.
+
+## Phases
+
+| # | Delivers | Gate to next phase |
+|---|---|---|
+| 0 | ADR 009, doc hygiene, sign-out fix | ADR merged, sign-out change green |
+| 1 | Export format v3: recurring_movements in, v2 frozen | Round-trip of v1/v2/v3 green |
+| 2 | Snapshot pipeline (transactional export, upload, retention) | Hash-mismatch test green |
+| 3 | Health visibility in Profile | — |
+| 4 | Restore confidence (CI round-trip, in-app verify, drill doc) | **Flag flips here** |
+| 5 | Engine decommission + cloud cleanup | — |
+
+### Phase 0 — ADR 009, hygiene, sign-out
+
+ADR 009 is written and carries the decision, the alternatives table, the trigger and restore-fork
+rules, the encryption deferral and the forbidden list. Read it rather than this summary.
+
+Doc hygiene (2026-08-13): `docs/sync/PLAN.md` and `docs/sync/AUDIT.md` moved to `docs/archive/sync/`,
+their surviving findings absorbed above, and the line-number citations replaced with symbol names.
+Seven documents described three different architectures at once with nothing marking which sentence
+was live; that cost a wrong salvage verdict in this very file (see below).
+
+**The sign-out fix.** `SignOutUseCase` → `AuthRepository.signOut()` → `DefaultAuthRepository.signOut()`
+→ `client.auth.signOut()`, with no `SignOutScope` argument. supabase-kt 3.7.0's `AuthImpl.signOut`
+posts `logout` whenever a session exists — for **every** scope, `LOCAL` included — and wraps that
+post in `catch (e: RestException)`. A network failure is `HttpRequestException`, an `IOException`,
+so it is not a `RestException`: it escapes before `clearSession()` runs and **the device stays
+signed in**. `SignOutScope.LOCAL` narrows which sessions the server revokes; it does not remove the
+round-trip.
+
+Under ADR 009 that is no longer cosmetic. The pipeline uploads only while a session exists, so
+**signing out is the mechanism for ceasing to upload to an account.** A sign-out that fails
+silently means the next background snapshot still goes to the account the user believes they left.
+The disclosure of Decision 5 rests on it too — it fires on the first upload to a *new* destination,
+which never happens if the old session never ended.
+
+**Shipped** in `336de6a3` + `41940308`. `signOut()` runs the local clear unconditionally — outside
+the swallow, so a broken session store propagates instead of being reported as success — and
+attempts the server-side revoke as best effort, returning `SignOutResult.Revoked` / `LocalOnly`
+when only the revoke failed. The accepted
+cost is a refresh token that stays valid remotely until it expires when the sign-out happened
+offline; the alternative leaves the user signed in to an account they are actively trying to
+abandon, which is the worse failure under this plan.
+
+**One method, not two.** The abandoned `9b86dfdb` added `signOutLocally` *alongside* `signOut`,
+arguing the Perfil button wanted the strictest sign-out and could surface a failure to a user free
+to ignore it. That argument held while its consumer was a non-dismissible dialog and inverts here —
+and after Phase 5 removes `SyncOrchestrator`, the Perfil button is the only sign-out caller left, so
+the split would leave one method dead. A failed remote revoke is therefore a qualified success, and
+the UI says so out loud rather than reporting an error while leaving the user signed in.
+
+**One property the tests pin**, because prose asserting it would not: `CancellationException` is
+rethrown before the generic catch. The test that pins it asserts the session survives cancellation,
+because asserting that `await()` throws cannot discriminate the mutation — cancelling a coroutine's
+own job makes `await()` report cancellation whatever the body did.
+
+**One property they do not.** `clearSession()` runs **outside** the swallow, so a broken session
+store still propagates — the user is still signed in and has to hear about it. That is the intended
+design and the code does it, but nothing enforces it: all three client factories in
+`DefaultAuthRepositorySignOutTest` build auth with `minimalConfig()`, whose in-memory
+`MemorySessionManager` cannot fail, so wrapping `clearSession()` in its own swallow leaves all four
+tests green. Recorded as a follow-up below.
+
+`Revoked` means the server did not refuse, not that a live token was destroyed: supabase-kt's
+`AuthImpl` carries `SIGN_OUT_IGNORE_CODES` for 401/403/404, so an already-invalid JWT returns
+normally.
+
+**Open follow-up — pin the propagating local clear.** The one Phase 0 property that is prose only.
+A test needs a session store that can fail, which `minimalConfig()` cannot supply; `AuthConfig`
+exposes `sessionManager` as a plain `var`, so the fix is to set a `SessionManager` whose
+`deleteSession()` throws *after* `minimalConfig()` runs, then assert `signOut()` propagates instead
+of returning `LocalOnly`. Until that test exists, wrapping `clearSession()` in the swallow is an
+undetectable regression. Not written in Phase 0 — logged here so Phase 5, which rewrites
+`DeleteUserAccountUseCase` around the same method, does not inherit the same blind spot.
+
+Salvage of the 25 abandoned commits, decided per commit:
+
+- `9b86dfdb` (`SignOutLocallyUseCase`) — **re-apply, do not cherry-pick.** Its earlier verdict in
+  this file ("no consumer exists on trunk, park it") was correct when the consumer was the
+  branch-only re-point dialog, and is wrong now: the consumer is the Perfil button. Its KDoc
+  references `RepointBackupDestinationUseCase`, which does not exist and never will — rewrite the
+  prose against the snapshot pipeline before it lands.
+- `4b0b6402` (`OP_TIMEOUT` hung-logout test) — the test is a real candidate and pins a real
+  mechanism. It also edits `BackupDestinationViewModel`, which does not exist on trunk; only the
+  `DefaultAuthRepositorySignOutTest` half is portable. Its timeout finding is recorded in Phase 2b.
+- The other 22 repair the engine this plan deletes. They die with it.
+
+### Phase 1 — recurring_movements into the export format (v3)
+
+Commit order: ① freeze v2 → ② v3 with recurring → ③ versioned sweep.
+
+- **Freeze v2 first.** `BACKUP_SCHEMA_VERSION` is currently 2 and v2 files are read by the
+  *current* DTO (`ExportPayloadDto`). Adding a field and bumping to 3 would silently reinterpret
+  v2 files with v3's shape — the exact failure `BackupV1` exists to prevent (read its KDoc).
+  Create `BackupV2` (own frozen type + hand-written fixture + `BackupV2CompatibilityTest`),
+  then make v3 the current shape with its own fixture and test.
+- `RecurringMovementDto` fields: id, name, type, amount, description, categoryId, accountId,
+  frequency, dayOfMonth, isActive, **lastConfirmedPeriod** — without the last one a restore
+  re-mints the already-confirmed month.
+- **Extend the dangling-category scrub to recurring.** `exportToJson` nulls the categoryId of
+  transactions whose category is tombstoned (`DefaultBackupRepository`); recurring_movements
+  carries the same composite FK `(categoryId, type)`, so without the same scrub the exported file
+  fails its own import.
+- **Version the import sweep — the data-loss trap.** Today's import deliberately leaves
+  recurring untouched ("the export format does not include them, so wiping them would destroy
+  data that no backup can restore"). With v3 the sweep includes recurring **only for v3+
+  payloads**; importing a v1/v2 file must keep leaving local recurring intact. Pin both sides
+  with tests: *importing v1/v2 leaves recurring untouched; importing v3 replaces it*.
+- A new SELECT in `recurring_movements.sq`. Flat selects exist (`selectActive:`, `find:`,
+  `selectPending:`) but none returns every live row: `selectActive` filters `isActive = 1`, so
+  exporting through it would drop every paused template. Adding a SELECT is not a migration.
+- `ImportStats` gains a `recurring` count (today: accounts/categories/transactions only), plus
+  the UI message that reports it.
+
+Nothing else ships until this phase is merged and green — without it, a snapshot restore loses
+recurring movements on device loss.
+
+### Phase 2 — snapshot pipeline
+
+Three sub-phases, three PR series: the transactional refactor is its own risk and must be
+reviewable alone.
+
+**2a — transactional export.** `exportToJson` currently does three independent `Flow.first()`
+reads — a write between them corrupts the snapshot. SQLDelight transactions are synchronous
+blocks, so `.first()` cannot run inside one: switch the export to direct queries
+(`executeAsList()`) inside a single `transactionWithResult`. `DefaultBackupRepository` already
+holds the `db`; the refactor is contained to that class.
+
+**2b — storage.** Add `storage-kt` to the catalog (BOM 3.7.0 currently ships only auth-kt +
+postgrest-kt; zero Storage usage exists in the repo). Bucket + RLS restricted to the owning
+user — model it on the row-table policies named above — created as a SQL migration under
+`supabase/`, where that CLI infra already exists. Integrity: SHA-256 of the payload + sidecar
+manifest (filename, hash, format version, per-table row counts); after upload, read back and
+verify the hash before marking success. KMP has no SHA-256 in the common stdlib: use okio's
+`ByteString.sha256()` if okio is already transitive, else an `expect/actual` over
+`java.security.MessageDigest` / CommonCrypto.
+
+**The request timeout is 10s**, and it is not configured here. supabase-kt 3.7.0's
+`KtorSupabaseHttpClient.applyDefaultConfiguration` installs `HttpTimeout` on every client it
+builds, custom engine included, reading `SupabaseClientBuilder.requestTimeout`, whose default is
+`10.seconds`. `SupabaseModule` overrides nothing, so that default is what runs. Size upload
+retries and any outer timeout above it. **Caveat**: read once out of the Gradle cache on
+2026-08-13 and nothing enforces it — a BOM bump can change it silently. Installing `HttpTimeout`
+explicitly in `SupabaseModule` would make it visible, but it also moves the sync push path, so it
+belongs to its own unit.
+
+**2c — orchestration.**
+
+| Concern | Design |
+|---|---|
+| Dirty flag | `max(updatedAt)` across the 4 tables (new SELECTs; `softDelete` already bumps `updatedAt`, so deletes mark dirty) vs `lastSuccessfulBackupAt` in `AppPreferences` — the facade already holds cursor/lastSyncedAt keys |
+| Trigger | new `backgroundEvents()` expect/actual, sibling of `resumeEvents()` (ProcessLifecycleOwner ON_STOP / UIApplicationDidEnterBackground), capped at 1 automatic snapshot/day; **plus a staleness check on resume** — if the process died mid-upload, the next foreground retries (dirty flag is still set) |
+| Manual action | "Back up now" in Profile, through the existing `launchOp` concurrent-op guard |
+| Naming | `backup-v3-<ISO8601-UTC, colons replaced>.json` |
+| Retention | client-side prune (no server code exists): list bucket, parse timestamps from names, keep 7 daily + 8 weekly + 12 monthly, delete the rest. Pinned snapshots live under a `pinned/` prefix the prune never scans. "Pin before risky operation" action; every future DB schema migration must be preceded by a pinned snapshot |
+| Flag | `SNAPSHOT_BACKUP_ENABLED = false` in `core/backup/`, mirroring the `SyncKillSwitch` pattern (const + KDoc + grep-able). `bootstrapAppGraph` starts `BackupOrchestrator` behind it, the same pattern that gates `SyncOrchestrator.start()` in `AppGraph` today |
+
+**Verification**: gate green + a test proving an upload whose hash mismatches is NOT marked
+successful.
+
+### Phase 3 — health visibility
+
+- Persist `lastSuccessfulBackupAt`; show "Last backup: X ago" in Profile.
+- Warning state when staleness exceeds 3 days with pending mutations.
+- Every failure (serialization, network, hash mismatch, storage error) logs a distinct reason
+  and increments a visible failure indicator.
+- `ProfileOp` gains `BackingUp` / `VerifyingBackup`; the concurrent-op guard already emits
+  `OperationInProgress`. Automatic backups do NOT go through `ProfileViewModel` —
+  `BackupOrchestrator` is a singleton in the style of `SyncOrchestrator`. Register every new
+  binding in `AppGraphKoinTest`.
+- **Destination-change disclosure (ADR 009 Decision 5).** Before the first upload to an account
+  this device has not backed up to before, say on screen that this device's whole ledger — including
+  rows written under a previous account, since sign-out wipes nothing — goes into that account's
+  backup. A one-time disclosure, not a confirm-or-cancel dialog: nothing is downloaded, merged or
+  destroyed locally. Persist "already disclosed for this destination" so it fires once per account,
+  and pin it with a test — an undisclosed first upload is the failure this exists to prevent.
+- **Close the `SyncMutex` timeout defect** recorded in `docs/PROGRESS.md` before the pipeline
+  ships. `BackupOrchestrator` becomes a second holder alongside `DeleteUserAccountUseCase`, so a
+  stuck upload would block account deletion indefinitely — the same shape as the defect the engine
+  had, under a new name.
+
+### Phase 4 — restore confidence (the flag's gate)
+
+1. **CI round-trip, no device needed**: host test with in-memory JDBC SQLite (the pattern
+   `AppGraphKoinTest` already uses) — fixture across all 4 tables including tombstoned rows →
+   export → wipe → import → row-level equality.
+2. **In-app "Verify backup"**: download latest snapshot, check hash, parse, compare per-table
+   counts against local — **without applying it**. Result in UI.
+3. **Documented drill** added to the release checklist: after every DB schema bump, restore the
+   latest production snapshot on a clean emulator and compare.
+
+Only when all three pass does `SNAPSHOT_BACKUP_ENABLED` flip to `true`.
+
+### Phase 5 — decommission the engine
+
+Verified inventory (against trunk, 2026-08-13). Four buckets — delete, move, rewrite, keep:
+
+| Action | What |
+|---|---|
+| Delete, `:data` / `:domain` | the 9 files in `data/sync/`; `ConflictResolver`, `SyncCursorStore`, `SyncDataUseCase`, `SyncRepository`; the claim machinery (`ClaimLocalDataOnAuthenticationUseCase` + its un-gated observer in `bootstrapAppGraph` — local `userId` is dead metadata without a push) |
+| Delete, `:presentation` | `SyncOrchestrator`, `SyncController`, `SyncStatus`, `SyncEvent`, `DefaultSyncCursorStore`; the cursor keys in `AppPreferences`; the sync surface of `ProfileViewModel` (it consumes `SyncStatus`/`SyncController` for the Perfil badge) |
+| Delete, `:ui-android` | `hh/shared/SyncEventsHandler.kt` — whose own KDoc calls itself *"the ONLY collector of `SyncController.events`, and that is load-bearing"* — plus the sync references in `AppNavHost` and `AppNavigator`. **Miss these and the Android build breaks**, since the `:presentation` deletions above remove what they collect |
+| Move | the `appScope` single (`named("appScope")`) out of `syncModule` into CoreModule — it drives the claim observer today and `BackupOrchestrator` tomorrow; it is not engine property |
+| Rewrite | `DeleteUserAccountUseCase` — its "unclaim" and "cursor clear" steps are engine parts; remote delete becomes: delete the user's Storage objects + the auth user. Also carries the sign-out fix Phase 0 gave `DefaultAuthRepository.signOut()`: `DefaultAuthRepository.deleteAccount()` still calls bare `client.auth.signOut(SignOutScope.LOCAL)` after the `delete_account` RPC, with the identical defect — a network failure mid-request leaves the device holding a session for a user that no longer exists server-side. Its KDoc used to claim the call "clears the on-device session"; Phase 0 corrected that, **by inspection of `AuthImpl.signOut` — not by test.** `DefaultAuthRepositorySignOutTest` exercises `signOut()` only; nothing runs `deleteAccount()`'s call shape, so this defect is unpinned and a fix here has no red test to turn green. Not fixed in Phase 0: `deleteAccount()` is its own contract question (the account is gone either way, so "qualified success" may not even be the right shape there) |
+| Keep | `SyncMutex` and `SyncLogger`, renamed to drop the "Sync" prefix. After this phase the mutex's only holders are the rewritten `DeleteUserAccountUseCase` and `BackupOrchestrator`; the logger is what constraint 4 rests on, and its platform impls (`CrashReportingSyncLogger`, `PrintlnSyncLogger`) stay with it. Also `resumeEvents()`, and `importFromJson` + the export code — they are the product now |
+
+Also in scope, and easy to miss: `export(project(":data"))` in `presentation/build.gradle.kts` puts
+the whole engine in `JustChillKit`'s public ABI, for zero consumers. Re-check what that export
+still needs to carry once the deletions land.
+
+- The local DB schema is untouched (constraint 2). Dead columns stay dead in place.
+- **Cloud cleanup is destructive and outward-facing**: truncating the two tenants' row tables
+  (proven garbage — see the forensics above) happens only with explicit owner confirmation at the
+  moment, after a pinned and verified snapshot exists. Auth stays — Storage RLS needs it.
+- Remove `SYNC_TEMPORARILY_DISABLED` and its gates last, once nothing references the engine.
+- `supabase/migrations/20260610043814_sync_schema.sql` opens with "Mapping rules (see
+  docs/sync/PLAN.md)", a path archived on 2026-08-13. Deliberately NOT corrected in place: the
+  Supabase CLI can detect drift on an already-applied migration by content, and risking a migration
+  history mismatch on a project awaiting tenant cleanup costs more than a stale pointer in a comment.
+  Fix it in this phase, where `supabase/` is being touched anyway and the outcome can be verified
+  against the server. It is the **only** surviving pointer to either archived path, and that is
+  checkable rather than asserted: `rg 'docs/sync/(AUDIT|PLAN)\.md'` returns exactly three lines —
+  that SQL comment, the doc-hygiene note above recording the move, and this bullet quoting the
+  comment. The other two describe the old paths; only the SQL one still asks a reader to follow them.
+
+## Settled — do not reopen
+
+Shared accounts (rejected by the product definition, `PRODUCT_REQUIREMENTS.md` W-04, "Multi-cuenta
+compartida (parejas, equipos)"). Multi-device, which is a different rejection — ADR 006, one device
+at a time, and W-04 does not cover it. CRDTs,
+server-side LWW/conditional upsert, push-only row sync. Fixing the loop and keeping the engine.
+E2E encryption now (deferred by ADR — a Keystore-bound key dies with the phone). Any DB schema
+migration.

--- a/domain/CLAUDE.md
+++ b/domain/CLAUDE.md
@@ -34,12 +34,12 @@ Repository interfaces declared here must not reference SQLDelight, Supabase, or 
 framework. Example: `TransactionRepository` lives here; its `DefaultTransactionRepository`
 (SQLDelight-backed) lives in `:data`.
 
-The app is local-first with **optional** multi-device sync: auth ports live in `auth/`
-(`AuthRepository`, `ObserveSessionUseCase`, `SessionStatus`, claim use cases) and sync ports in
-`sync/` (`SyncRepository`, `SyncCursorStore`, `SyncDataUseCase`, `ConflictResolver` — pure LWW).
+The app is local-first; sync is **backup-only, one device at a time** (ADR 006). The row-replication
+engine below is scheduled for deletion (`docs/sync/ADR009_PLAN.md` Phase 5): auth ports live in
+`auth/` (`AuthRepository`, `ObserveSessionUseCase`, `SessionStatus`, claim use cases) and sync ports
+in `sync/` (`SyncRepository`, `SyncCursorStore`, `SyncDataUseCase`, `ConflictResolver` — pure LWW).
 Supabase implementations live in `:data`; the `SyncCursorStore` adapter lives in `:presentation`
-(`core/sync/DefaultSyncCursorStore.kt`).
-See `docs/sync/PLAN.md` and `docs/adr/001` / `docs/adr/002`.
+(`core/sync/DefaultSyncCursorStore.kt`). See `docs/adr/001` / `docs/adr/006` / `docs/adr/009`.
 
 ## Testing
 

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/auth/DeleteUserAccountUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/auth/DeleteUserAccountUseCaseTest.kt
@@ -90,7 +90,7 @@ class DeleteUserAccountUseCaseTest {
         verify(exactly = 0) { syncCursorStore.clear(any()) }
     }
 
-    // ── Failure observability (docs/sync/AUDIT.md §8) ─────────────────────────
+    // ── Failure observability (docs/archive/sync/AUDIT.md §8) ─────────────────────────
 
     /**
      * The failure this whole change exists for: a broken step used to be indistinguishable from a
@@ -151,7 +151,7 @@ class DeleteUserAccountUseCaseTest {
      * Once [AuthRepository.deleteAccount] has succeeded the account is gone server-side, so a
      * cancellation landing after it (e.g. the caller popping the Perfil screen mid-flight) must
      * not skip the local cleanup — otherwise local rows keep the userId of an account that no
-     * longer exists remotely (`docs/sync/AUDIT.md` §3, the precondition of the production sync
+     * longer exists remotely (`docs/archive/sync/AUDIT.md` §3, the precondition of the production sync
      * loop).
      */
     @Test

--- a/domain/src/androidHostTest/kotlin/com/emm/domain/auth/SignOutUseCaseTest.kt
+++ b/domain/src/androidHostTest/kotlin/com/emm/domain/auth/SignOutUseCaseTest.kt
@@ -1,13 +1,12 @@
 package com.emm.domain.auth
 
 import com.emm.domain.shared.error.DomainException
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class SignOutUseCaseTest {
 
@@ -15,12 +14,22 @@ class SignOutUseCaseTest {
     private val useCase = SignOutUseCase(repository)
 
     @Test
-    fun `invoke delegates signOut to repository`() = runTest {
-        coEvery { repository.signOut() } just Runs
+    fun `invoke delegates signOut to repository and returns Revoked unchanged`() = runTest {
+        coEvery { repository.signOut() } returns SignOutResult.Revoked
 
-        useCase()
+        val result = useCase()
 
+        assertEquals(SignOutResult.Revoked, result)
         coVerify(exactly = 1) { repository.signOut() }
+    }
+
+    @Test
+    fun `invoke propagates LocalOnly unchanged`() = runTest {
+        coEvery { repository.signOut() } returns SignOutResult.LocalOnly
+
+        val result = useCase()
+
+        assertEquals(SignOutResult.LocalOnly, result)
     }
 
     @Test

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/AuthRepository.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/AuthRepository.kt
@@ -27,7 +27,38 @@ interface AuthRepository {
      */
     suspend fun signUp(email: String, password: String): AuthUser?
 
-    suspend fun signOut()
+    /**
+     * Signs the user out. The server-side revoke is best effort; the local clear is attempted
+     * unconditionally, which is not the same as guaranteed — see *"Unconditionally is not
+     * guaranteed"* below.
+     *
+     * supabase-kt 3.7.0's `AuthImpl.signOut` posts a `logout` request whenever a session exists —
+     * for every `SignOutScope`, `LOCAL` included — and wraps that post in `catch (e: RestException)`.
+     * A network-level failure is `HttpRequestException`, an `IOException`, so it is not a
+     * `RestException`: it escapes the provider's own method before it clears the session, leaving
+     * the device signed in. `SignOutScope.LOCAL` narrows which sessions the SERVER revokes; it does
+     * not remove the round-trip or the exception it can throw.
+     *
+     * This app's backup pipeline uploads only while a session exists (ADR 009), so signing out is
+     * the only mechanism for ceasing to upload to an account. A sign-out that can fail silently on a
+     * flaky network would leave the next background snapshot going to the account the user believes
+     * they left. So the revoke is attempted, ITS failure is swallowed, and the local session is then
+     * cleared unconditionally — a failed revoke comes back as [SignOutResult.LocalOnly] rather than
+     * thrown.
+     *
+     * **Unconditionally is not guaranteed.** The local clear runs OUTSIDE that swallow on purpose,
+     * so it is the one failure this method lets propagate: if the session store itself breaks, the
+     * caller gets an exception and no [SignOutResult] at all, because the user is still signed in
+     * and has to hear about it. Returning a [SignOutResult] therefore means the device IS signed
+     * out; the two values only say whether the server was successfully told. Nothing pins that
+     * split today — the follow-up is named in `docs/sync/ADR009_PLAN.md`, Phase 0.
+     *
+     * The accepted cost: when the revoke could not be reached, the refresh token stays valid
+     * remotely until it expires naturally. The alternative — leaving the device signed in because a
+     * network round-trip failed — is worse: the user is actively trying to leave and the app would
+     * trap them mid-sign-out.
+     */
+    suspend fun signOut(): SignOutResult
 
     /**
      * Exchanges a Google ID token for a session.
@@ -38,8 +69,23 @@ interface AuthRepository {
 
     /**
      * Calls the remote `delete_account` RPC (removes the auth user and all remote rows), then
-     * clears the on-device session without a server round-trip — the auth user no longer exists
-     * server-side after the RPC, so a server-side sign-out call would fail.
+     * ATTEMPTS to clear the on-device session. Unlike [signOut], the local clear is not a guarantee
+     * here.
+     *
+     * The implementation asks for the narrowest sign-out scope because the auth user no longer
+     * exists server-side after the RPC — but that scope does not buy a local-only operation. It is
+     * the same provider behaviour [signOut] documents: supabase-kt 3.7.0 posts `logout` whenever a
+     * session exists, for every scope, and catches only `RestException`. A deleted user's JWT comes
+     * back 401/403/404, which the provider ignores by design, so the ordinary case does clear. A
+     * NETWORK failure does not: it is an `IOException`, it escapes the provider before the clear
+     * runs, and it surfaces here as [com.emm.domain.shared.error.DomainException.NetworkUnavailable]
+     * with the device still holding a session for a user that no longer exists.
+     *
+     * That is a known defect and it is deliberately NOT repaired with [signOut]'s
+     * swallow-then-clear shape: whether a delete whose remote half already succeeded should report
+     * a qualified success is its own contract question, deferred to Phase 5 of
+     * `docs/sync/ADR009_PLAN.md`. And unlike [signOut], nothing pins any of this — it is read off
+     * the provider's source, not off a failing test.
      */
     suspend fun deleteAccount()
 

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/ClaimLocalDataOnAuthenticationUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/ClaimLocalDataOnAuthenticationUseCase.kt
@@ -15,6 +15,10 @@ import kotlin.time.Duration.Companion.seconds
  * Long-running coordinator: whenever the session is [SessionStatus.Authenticated] AND there are
  * anonymous-local rows (userId IS NULL), claims those rows for the authenticated user immediately.
  *
+ * This is ownership, not transport — it stamps rows with a userId, it never pushes anything.
+ * Scheduled for deletion in Phase 5 of `docs/sync/ADR009_PLAN.md` along with the rest of the claim
+ * machinery: once the row-replication engine is gone there is no push left for that userId to enable.
+ *
  * Why reactive (observeUnclaimedCount) instead of triggering only on userId transition:
  * - Rows created WHILE already signed in get syncState='Pending' but userId=NULL (the insert
  *   queries never set userId; only claimAll does). The old distinctUntilChanged approach emitted

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/ClaimLocalDataRepository.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/ClaimLocalDataRepository.kt
@@ -8,6 +8,10 @@ import kotlinx.coroutines.flow.Flow
  *
  * Idempotent: rows that already carry a userId are left untouched — the WHERE clause is the guarantee.
  * Implementation must execute all updates inside a single atomic transaction.
+ *
+ * This whole claim machinery is scheduled for deletion in Phase 5 of `docs/sync/ADR009_PLAN.md`:
+ * once the row-replication engine is gone, a local `userId` is ownership metadata for a backup
+ * upload, not a precondition for a push that no longer exists.
  */
 interface ClaimLocalDataRepository {
 
@@ -26,6 +30,8 @@ interface ClaimLocalDataRepository {
      * Emits the total number of anonymous-local rows (userId IS NULL) across the four tables.
      * Drives reactive claiming: while a user is authenticated, any value > 0 means there are
      * freshly-created local rows that must be claimed for the current user so they can sync.
+     * (Scheduled for deletion in Phase 5 of `docs/sync/ADR009_PLAN.md` along with the rest of
+     * this interface — see the class KDoc above.)
      */
     fun observeUnclaimedCount(): Flow<Long>
 }

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/DeleteUserAccountUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/DeleteUserAccountUseCase.kt
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.seconds
  * once it succeeds the account is gone server-side, so a cancellation landing after it (e.g. the
  * caller popping the Perfil screen mid-flight, cancelling `viewModelScope`) must not skip the local
  * cleanup. Skipping it would leave local rows tagged with the userId of an account that no longer
- * exists on the server, which `docs/sync/AUDIT.md` §3 names as the precondition of the production
+ * exists on the server, which `docs/archive/sync/AUDIT.md` §3 names as the precondition of the production
  * sync loop this whole use case exists to close.
  *
  * Resolving the session is bounded by [SESSION_RESOLVE_TIMEOUT]. The whole flow holds the shared
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.seconds
  * Every step is logged through [SyncLogger] on failure, naming which one broke, before the
  * original exception is rethrown unchanged. This flow used to fail completely silently in
  * production with zero trace of which step (or the caller's UI guard) ate the failure — see
- * `docs/sync/AUDIT.md` §8. [CancellationException] is never logged as a failure: the user simply
+ * `docs/archive/sync/AUDIT.md` §8. [CancellationException] is never logged as a failure: the user simply
  * leaving the screen is not a deletion failure.
  *
  * NOTE: [DeleteAccountUseCase] in `com.emm.domain.account` handles FINANCIAL account deletion
@@ -68,7 +68,7 @@ class DeleteUserAccountUseCase(
         // Steps 2-3 run under NonCancellable: once step 1 has succeeded the account is gone
         // server-side, so a cancellation landing here (e.g. the caller leaving the screen) must
         // not leave local rows still tagged with a userId that no longer exists remotely — see the
-        // class KDoc and `docs/sync/AUDIT.md` §3.
+        // class KDoc and `docs/archive/sync/AUDIT.md` §3.
         withContext(NonCancellable) {
             // Step 2: revert owned local rows to anonymous-local (userId = NULL, syncState = Pending).
             withStepLogging("unclaim") { claimLocalDataRepository.unclaimAll(userId) }

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/SignOutResult.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/SignOutResult.kt
@@ -1,0 +1,37 @@
+package com.emm.domain.auth
+
+/**
+ * Outcome of [AuthRepository.signOut]. Two things can fail there, and only one of them is reported
+ * through this type.
+ *
+ * **A failed server-side revoke returns [LocalOnly].** It is a qualified success, never a thrown
+ * error: the user's intent — leave this account, on this device — is honored either way, so
+ * surfacing it as an exception would report a sign-out failure to someone who is, in fact, signed
+ * out. The caller is expected to tell [Revoked] and [LocalOnly] apart and word the confirmation
+ * accordingly.
+ *
+ * **A failed local clear throws.** [AuthRepository.signOut] runs the local clear OUTSIDE the
+ * swallow that covers the revoke, so if the session store itself breaks, the exception propagates
+ * and no value of this type is ever produced — the user is still signed in and has to hear about it.
+ * Receiving a [SignOutResult] at all therefore means the device is signed out; it never means "the
+ * clear may or may not have happened".
+ */
+sealed interface SignOutResult {
+
+    /**
+     * The server-side revoke request did not fail. This is NOT a guarantee that a live token was
+     * destroyed: supabase-kt's `AuthImpl.signOut` treats a 401/403/404 response the same as success
+     * (its `SIGN_OUT_IGNORE_CODES`), because that shape means the session was already invalid or
+     * gone server-side — the local clear still runs either way, and this result is still reported as
+     * [Revoked]. Read [Revoked] as "the server did not refuse the sign-out", not as "a live token
+     * was destroyed".
+     */
+    data object Revoked : SignOutResult
+
+    /**
+     * The local session is cleared, but the server-side revoke could not be reached (offline, a
+     * timeout, or any other transport failure). The refresh token stays valid remotely until it
+     * expires naturally — the accepted cost documented on [AuthRepository.signOut].
+     */
+    data object LocalOnly : SignOutResult
+}

--- a/domain/src/commonMain/kotlin/com/emm/domain/auth/SignOutUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/emm/domain/auth/SignOutUseCase.kt
@@ -1,7 +1,7 @@
 package com.emm.domain.auth
 
 /**
- * Signs the user out by invalidating the remote session.
+ * Signs the user out. See [AuthRepository.signOut] for what the returned [SignOutResult] means.
  *
  * Local data is NOT wiped: rows are kept on-device and remain accessible while offline.
  * Removing or re-anonymising local rows on sign-out is a :data / :app concern and must
@@ -9,7 +9,5 @@ package com.emm.domain.auth
  */
 class SignOutUseCase(private val authRepository: AuthRepository) {
 
-    suspend operator fun invoke() {
-        authRepository.signOut()
-    }
+    suspend operator fun invoke(): SignOutResult = authRepository.signOut()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,6 +96,10 @@ supabase-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt"
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktorClientOkhttp" }
 # iOS engine — pinned to the same Ktor version as the OkHttp (Android) engine.
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktorClientOkhttp" }
+# TEST ONLY. Lets a host test drive a real SupabaseClient whose transport is scripted, which is the
+# only way to prove what the auth provider does to the local session under a given network outcome.
+# Same Ktor version as the two engines above on purpose — a split would resolve two Ktor versions.
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktorClientOkhttp" }
 # iOS SQLDelight driver — same SQLDelight version as the Android driver.
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/core/sync/SyncKillSwitch.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/core/sync/SyncKillSwitch.kt
@@ -6,11 +6,12 @@ package com.emm.justchill.core.sync
  * Why it exists: the push dropped every row carrying a stale `userId` while `countPending` kept
  * counting them, so the debounced-writes trigger re-fired every few seconds forever, and the cycles
  * that did reach Supabase wrote dangling cross-tenant rows. The app is local-first, so switching
- * sync off costs nothing and stops the corruption. The sync layer is under redesign —
- * see `docs/sync/PLAN.md`.
+ * sync off costs nothing and stops the corruption.
  *
- * Temporary. To turn sync back on, flip this to `false`: nothing was removed, every Koin binding,
- * test and engine class is still wired. Grep this name to find every site it gates. Delete the
- * constant when the redesign lands.
+ * **This stays `true` forever.** `docs/adr/009-backup-is-a-snapshot-not-row-replication.md` replaces
+ * row replication with snapshot backup and deletes this engine rather than repairing it, so there
+ * is no "turn sync back on" any more — flipping this to `false` would re-enable the loop above.
+ * The constant and its gates are removed in the last phase of `docs/sync/ADR009_PLAN.md`, once
+ * nothing references the engine. Grep this name to find every site it gates.
  */
 const val SYNC_TEMPORARILY_DISABLED: Boolean = true

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/profile/ProfileEffect.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/profile/ProfileEffect.kt
@@ -17,6 +17,14 @@ sealed interface ProfileEffect : UiEffect {
 
 sealed interface ProfileMessage {
     data object SessionClosed : ProfileMessage
+
+    /**
+     * [com.emm.domain.auth.SignOutUseCase] returned [com.emm.domain.auth.SignOutResult.LocalOnly]:
+     * the local session was cleared, but the server-side revoke could not be reached. Distinct from
+     * [SessionClosed] so the snackbar can say the server was not reached, rather than implying a
+     * clean revoke that did not happen.
+     */
+    data object SessionClosedLocallyOnly : ProfileMessage
     data object AccountDeleted : ProfileMessage
     data object ExportDone : ProfileMessage
     data object ExportFailed : ProfileMessage

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/profile/ProfileViewModel.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/profile/ProfileViewModel.kt
@@ -5,6 +5,7 @@ import com.emm.domain.account.AccountRepository
 import com.emm.domain.auth.DeleteUserAccountUseCase
 import com.emm.domain.auth.ObserveSessionUseCase
 import com.emm.domain.auth.SessionStatus
+import com.emm.domain.auth.SignOutResult
 import com.emm.domain.auth.SignOutUseCase
 import com.emm.domain.category.CategoryRepository
 import com.emm.domain.shared.backup.BackupRepository
@@ -98,7 +99,7 @@ class ProfileViewModel(
      *
      * The guard reports instead of swallowing: a confirmed intent arriving while another op is in
      * flight used to return silently with no effect and no state change — indistinguishable on
-     * screen from the delete-account RPC never firing at all (`docs/sync/AUDIT.md` §8, candidate 1).
+     * screen from the delete-account RPC never firing at all (`docs/archive/sync/AUDIT.md` §8, candidate 1).
      * One generic [ProfileMessage.OperationInProgress] covers all four ops here on purpose — this
      * guard is shared, and must not grow a per-op branch.
      */
@@ -125,9 +126,12 @@ class ProfileViewModel(
         op = ProfileOp.SigningOut,
         onError = { e -> ProfileEffect.ShowError(e) },
     ) {
-        signOut.invoke()
         // Local data is intentionally NOT wiped on sign-out (see SignOutUseCase doc).
-        sendEffect(ProfileEffect.Notify(ProfileMessage.SessionClosed))
+        val message = when (signOut.invoke()) {
+            SignOutResult.Revoked -> ProfileMessage.SessionClosed
+            SignOutResult.LocalOnly -> ProfileMessage.SessionClosedLocallyOnly
+        }
+        sendEffect(ProfileEffect.Notify(message))
     }
 
     private fun deleteAccount() = launchOp(

--- a/presentation/src/commonMain/kotlin/com/emm/justchill/hh/shared/ProfileMessageText.kt
+++ b/presentation/src/commonMain/kotlin/com/emm/justchill/hh/shared/ProfileMessageText.kt
@@ -6,10 +6,20 @@ import com.emm.justchill.hh.profile.ProfileMessage
 // ui-android/.../hh/profile/ProfileEntries.kt. The strings are UI copy and are preserved verbatim.
 fun ProfileMessage.toText(): String = when (this) {
     ProfileMessage.SessionClosed -> "Sesión cerrada. Tus datos siguen en este teléfono."
+
+    ProfileMessage.SessionClosedLocallyOnly ->
+        "Sesión cerrada acá; no llegué al servidor, así que tu acceso remoto sigue activo hasta " +
+            "que expire. Cerrá sesión con internet para cortarlo. Tus datos siguen en este teléfono."
+
     ProfileMessage.AccountDeleted -> "Cuenta eliminada. Tus datos siguen en este teléfono."
+
     ProfileMessage.ExportDone -> "Listo, tu data está guardada."
+
     ProfileMessage.ExportFailed -> "No pude exportar — capaz no hay espacio en tu celu?"
+
     is ProfileMessage.ImportDone -> "Listo — $transactions movimientos importados."
+
     ProfileMessage.ImportFailed -> "No pude importar el archivo — capaz está dañado."
+
     ProfileMessage.OperationInProgress -> "Espera a que termine la operación en curso."
 }

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/ProfileEntries.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/ProfileEntries.kt
@@ -118,7 +118,17 @@ private fun ProfileEntry(
                         ProfileMessage.OperationInProgress,
                         -> EmmSnackbarTone.Error
 
-                        else -> EmmSnackbarTone.Success
+                        // A chosen branch, not a default: EmmSnackbarTone only has two values today,
+                        // so SessionClosedLocallyOnly (the server-side revoke was not reached) is a
+                        // deliberate Success here rather than an unclassified fallback — the sign-out
+                        // the user asked for did succeed locally. The next message added to
+                        // ProfileMessage has to extend this list explicitly; there is no `else`.
+                        ProfileMessage.SessionClosed,
+                        ProfileMessage.SessionClosedLocallyOnly,
+                        ProfileMessage.AccountDeleted,
+                        ProfileMessage.ExportDone,
+                        is ProfileMessage.ImportDone,
+                        -> EmmSnackbarTone.Success
                     },
                 )
             }

--- a/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/ProfileScreen.kt
+++ b/ui-android/src/androidMain/kotlin/com/emm/justchill/hh/profile/ProfileScreen.kt
@@ -439,7 +439,7 @@ private fun ProfileRow(icon: ImageVector, label: String, meta: String, metaIsPri
 
 // Kept separate from ProfileRow's default parameter list on purpose: LongParameterList caps
 // composables at 5 params (config/detekt/detekt.yml), and ProfileRowWithTrailing already carries
-// the `enabled` lever for the few rows that need it (docs/sync/AUDIT.md §8, candidate 4).
+// the `enabled` lever for the few rows that need it (docs/archive/sync/AUDIT.md §8, candidate 4).
 @Composable
 private fun ChevronTrailing(enabled: Boolean) {
     val colors = LocalEmmColors.current


### PR DESCRIPTION
Replaces the row-replication sync engine with **snapshot backup**: the complete versioned JSON export, uploaded periodically to Supabase Storage. This is Phase 0 — the decision, the documentation it rests on, and the one code fix the later phases cannot ship without.

No engine code is deleted here. Deletion is Phase 5, and only after Phases 2–4 prove the replacement works.

## Why the engine goes instead of getting repaired

Row-level sync has no live scenario in this product. The product definition already rejected shared accounts (`PRODUCT_REQUIREMENTS.md` W-04), and ADR 006 already reduced sync to one device at a time. What survives that is a backup, and a backup of a single-writer local-first app is a snapshot — not a per-row merge with conflict arbitration, a cursor, and a claim protocol.

Production forensics back it: two tenants, 64 rows total, **zero rows with a non-null `deleted_at` anywhere** — no soft delete ever reached production. All 13 of the second tenant's transactions point at an account owned by the first, which the public schema permitted because it deliberately has no foreign keys. The engine was arbitrating conflicts over data it was already corrupting.

## What is in this PR

**The decision** — [ADR 009](docs/adr/009-backup-is-a-snapshot-not-row-replication.md). Supersedes parts of ADR 001 and 006 and renders 002 dormant, decision by decision in its header. Carries the alternatives table, the trigger and restore-fork rules, the encryption deferral, and the forbidden list.

**The build order** — [`docs/sync/ADR009_PLAN.md`](docs/sync/ADR009_PLAN.md), now the single live sync document. Seven documents previously described three different architectures at once with nothing marking which sentence was current; `docs/sync/PLAN.md` and `docs/sync/AUDIT.md` move to `docs/archive/sync/` with their five surviving findings absorbed into the plan.

**The sign-out fix** — the only production code here, and it is a prerequisite rather than a cleanup. Under ADR 009 the pipeline uploads only while a session exists, so **signing out is the mechanism for ceasing to upload to an account.** supabase-kt 3.7.0's `AuthImpl.signOut` posts `logout` whenever a session exists — for every scope, `LOCAL` included — and wraps that post in `catch (e: RestException)`. A network failure is `HttpRequestException`, an `IOException`, so it escapes before `clearSession()` runs and the device stays signed in. A sign-out that fails silently means the next background snapshot still goes to the account the user believes they left.

`signOut()` now runs the local clear unconditionally and treats the server revoke as best effort, returning `SignOutResult.Revoked` / `LocalOnly`. The accepted cost is a refresh token that stays valid remotely until it expires when the sign-out happened offline; the alternative leaves the user signed in to an account they are actively trying to abandon.

## Review history

A blind dual-judge review over the ADR and sign-out commits returned **APPROVED, zero critical findings**. Both judges independently ran mutation analysis over the four sign-out tests and confirmed none is inert — the cancellation test does go red if the `CancellationException` rethrow is deleted.

All five confirmed findings were prose, not implementation, and are fixed in the last two commits. The instructive one: the commit that banned `file:line` citations broke two of them in the same commit, because adding a six-line `ARCHIVED` header to the archived audit moved every line a citation pointed at. And the plan asserted "two properties the tests pin" when only one is pinned — inside the document whose new rule is that prose may not claim guarantees nothing sustains.

A follow-up review then found that deleting one false claim had left the sentence it was echoing alive in four further places, including the test's own assertion message — fixed in the last code commit, `fix(auth): correct the KDoc contract and drop the flake from the test`.

## Deliberately not in this PR

- **`deleteAccount()` still has the same call-shape defect** as the old `signOut()`. It is its own contract question — the account is gone either way, so "qualified success" may not be the right shape there — and belongs to Phase 5, where its remote half is rewritten anyway.
- **A test pinning that a broken session store propagates.** It cannot fail today: all three factories build auth with `minimalConfig()`, whose `MemorySessionManager` stores into an `AtomicReference` and cannot throw. Named as a Phase 0 follow-up in the plan, with the mechanism that would implement it.
- **Eleven `file:line` citations in `docs/PROGRESS.md`**, two of them already rotted. Its own unit — sweeping them here would be opportunistic cleanup inside a correction batch.
- **One stale doc path, on purpose**: the `sync_schema` migration header. The Supabase CLI can detect drift on an applied migration by content, and risking a migration history mismatch on a project awaiting tenant cleanup costs more than a stale pointer in a comment. Corrected in Phase 5, where `supabase/` is touched anyway and the outcome can be verified against the server.

## Verification

`./gradlew qualityGate` green — detekt over every module source set holding code, the host test suites, dev lint, the iOS compile, and `:build-logic:test`.

`DefaultAuthRepositorySignOutTest`: 4 tests, 0 failures. The cancellation test's `requestTimeout` was flaky against real `Dispatchers.IO` threads at 500ms; `requestTimeout` is now a required parameter of the factory and the cancellation test takes a non-competing 10s, which stays under `runTest`'s 60s default so a regression fails on the session assertion rather than on a coroutine-leak timeout.

No DB schema migration, here or anywhere in this plan. Real accumulated data is on the device.

## Next

Phase 1 — export format v3 with `recurring_movements`, in the order: freeze v2, then v3, then version the import sweep. Without it a snapshot restore loses recurring movements on device loss.
