### PR TITLE
docs(skills): repoint auditoria at engram and hoist the gradle ban

### DIFF
--- a/.claude/skills/auditoria/SKILL.md
+++ b/.claude/skills/auditoria/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 allowed-tools: Read, Grep, Glob, Bash, Write
 metadata:
   author: "emm"
-  version: "1.2"
+  version: "1.3"
 ---
 
 ## Activation Contract
@@ -25,6 +25,7 @@ NOT here:
 - Lead with what is broken; no praise, no hedging.
 - Severity `CRITICAL`/`WARNING`/`NIT` only (`docs/WORKFLOW.md`).
 - Never edit or commit ANYTHING — code, docs, config, skills. The auditor writes no file in this repo; its output IS the report.
+- Never run Gradle — no `qualityGate`, no compile task. A finding only a Gradle task can prove is UNPROVEN, plus the exact command for the main thread.
 - Aggression never licenses inflated severity; unevidenced is worse than silent.
 - Verify against real code, never memory or a doc's claim.
 - Wrong premise → say so with evidence.
@@ -46,7 +47,7 @@ A local fix belongs in the finding's `fix` field; `## Plan` is only for REFACTOR
 
 1. Restate target, boundary, budget; read that `references/gates.md` row, then the code.
 2. Findings: evidence, defect, consequence, fix.
-3. Never re-raise a claim `docs/PROGRESS.md` records as failed verification.
+3. Never re-raise a claim already recorded as failed verification — that chronicle lives in engram; `mem_search` the claim first.
 4. Rank by blast radius; emit the verdict, plus the plan on REFACTORIZAR/REHACER.
 
 ## Output Contract
@@ -56,8 +57,7 @@ A local fix belongs in the finding's `fix` field; `## Plan` is only for REFACTOR
 - `## Premisa` — only if the premise was wrong, with evidence.
 - `## Plan` — only on REFACTORIZAR/REHACER; ordered steps, one writer unit each.
 - `## Cobertura` — required if the budget was hit OR the target is the whole project: read vs unread.
-- Persist only if the user asks or findings exceed five; else chat. Persistence is `mem_save` plus an Artifact — never a `.md` in this repo: an audit is chronicle, and the chronicle lives in git and engram (`docs/work/README.md`). A finding that needs work becomes a ticket the MAIN THREAD opens in `docs/work/backlog/`; the auditor proposes it and never writes it.
-- `docs/archive/sync/AUDIT.md` is a PRIOR audit: a read-only input, never a write target — and read it for *why*, never for what to do next.
+- Persist only if the user asks or findings exceed five; else chat. Persistence is `mem_save` plus an Artifact, never a `.md` in this repo — an audit is chronicle (`docs/work/README.md`). A finding that needs work becomes a backlog ticket the MAIN THREAD opens; the auditor only proposes it.
 - Nothing else: no reading summary, no pleasantries.
 
 ## References

--- a/.claude/skills/auditoria/references/gates.md
+++ b/.claude/skills/auditoria/references/gates.md
@@ -8,7 +8,7 @@ Read the row for the target before opening any source file.
 | Architecture / module | `CLAUDE.md` `## Architecture`, then that module's own `CLAUDE.md` (only `androidApp/`, `ui-android/`, `presentation/`, `domain/`, `data/` ship one; `build-logic/`, `iosApp/`, `supabase/` have none) | 20 |
 | Sync | `docs/work/epics/E01-snapshot-backup.md` and `docs/adr/009-backup-is-a-snapshot-not-row-replication.md` BEFORE any source file. The forensic audit is archived at `docs/archive/sync/AUDIT.md` — read it for *why*, never for what to do next | 20 |
 | Supabase / SQLDelight migrations | `docs/archive/sync/AUDIT.md`, then `supabase/migrations/` against the SQLDelight schema. Flag any drift — this is the class that broke production for two months (commit `72a9b03`) | 15 |
-| `:presentation` commonMain | the exported-iOS surface. Any `java.*` or `android.*` reference is CRITICAL; the only proof is `./gradlew :presentation:compileKotlinIosSimulatorArm64`, which the MAIN THREAD runs — the auditor reports the suspect imports it found and marks the finding UNPROVEN | 20 |
+| `:presentation` commonMain | the exported-iOS surface. Any `java.*` or `android.*` reference is CRITICAL; the only proof is `./gradlew :presentation:compileKotlinIosSimulatorArm64` — UNPROVEN until the main thread runs it | 20 |
 | Dates | `docs/CODE_QUALITY.md` `## Dates` — the live rule is an injected `Clock` AND an injected `TimeZone`, neither carrying a default, and it names its own allowed exceptions | 15 |
 | `.github/` pipelines | `CLAUDE.md` `## Gotchas` — pinned SHAs, the `git describe --match "v[0-9]*"` filter, secrets via `env:` | 10 |
 | Docs vs code | the code is the truth, the doc is the suspect | 20 |
@@ -19,4 +19,3 @@ Read the row for the target before opening any source file.
 
 - The budget counts source files opened, not the docs in the `Read first` column.
 - On hitting the budget, stop and emit `## Cobertura`. Never silently truncate.
-- The auditor never runs Gradle — no `qualityGate`, no compile task. When a finding can only be proven by a Gradle task, report it as UNPROVEN and name the exact command for the main thread to run.


### PR DESCRIPTION
Applies the four findings from the `skill-improver` audit of `.claude/skills/auditoria` (v1.2 → 1.3).

## Warnings fixed
- **Dead pointer**: Execution step 3 cited failed-verification records in `docs/PROGRESS.md`. Those records existed when the rule was written (`2073e7a7`) but moved to engram when PROGRESS was trimmed to the orientation page. The step now says to `mem_search` the claim first.
- **Buried constraint**: "never run Gradle → report UNPROVEN + exact command" lived only in `gates.md ## Scope budget`, below the table — and step 1 only mandates reading *the target's row*. Hoisted into `SKILL.md ## Hard Rules`; the `:presentation` row trimmed to one clause.

## Nits fixed
- The `AUDIT.md` read-for-why rule was declared twice (Output Contract + gates.md Sync row); the Output Contract bullet is gone — one declaration.
- Persistence bullet compressed, same semantics.

Frontmatter `description` unchanged, so the skill registry needs no refresh.
